### PR TITLE
Packaging changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /src/main/webapp/WEB-INF/backup
 /src/main/webapp/WEB-INF/LocalDB
 /bin/
+/src/main/webapp/WEB-INF/applicationPath.lock

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,41 @@
                 <javadoc.opts>-Xdoclint:none</javadoc.opts>
             </properties>
         </profile>
+        <profile>
+            <!-- Builds a zip file containing the built war file, along with the supplemental directory -->
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>2.6</version>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/pwm.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Disables source and javadoc jar file creation.  Handy when wanting to run quick development builds -->
+            <id>developer</id>
+            <properties>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <source.skip>true</source.skip>
+            </properties>
+        </profile>
     </profiles>
 
     <build>
@@ -112,6 +147,26 @@
                     <archiveClasses>true</archiveClasses>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/src</outputDirectory>
+                            <resources>
+                                <resource><directory>src/main/java</directory></resource>
+                                <resource><directory>src/main/resources</directory></resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+          </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archiveClasses>true</archiveClasses>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/assembly/pwm.xml
+++ b/src/assembly/pwm.xml
@@ -1,0 +1,17 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+
+    <id>pwm-assembly</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <includes>
+                <include>supplemental/**</include>
+                <include>target/*.war</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>


### PR DESCRIPTION
Added some changes to how the project's artifacts are packaged.  So now the build will:
* Create a jar file for compiled pwm classes and resources, and put under the webapp's WEB-INF/lib folder.
* Package src files in pwm the previously-mentioned jar file.
* Create a zip output file, containing the project's war file, along with the supplemental directory.

Also added a profile for development, which disables the creation of javadoc and source jars.  Handy for doing quick builds from the command-line.

@jrivard Please review and merge