### PR TITLE
Changed where variable replacement in BuildInformation.properties is defined.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,22 +70,6 @@
     </profiles>
 
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-                <includes>
-                    <include>**/BuildInformation.properties</include>
-                </includes>
-            </resource>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>false</filtering>
-                <excludes>
-                    <exclude>**/BuildInformation.properties</exclude>
-                </excludes>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -165,8 +149,28 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>replace-build-properties</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <filtering>true</filtering>
+                                    <directory>src/main/resources</directory>
+                                    <includes>
+                                        <include>password/pwm/BuildInformation.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
-          </plugin>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Changed where variable replacement in BuildInformation.properties is defined.

Instead of using the pom resource definition mechanism for causing variable replacement to occur in BuildInformation.properties, I've updated the pom to explicitly perform variable replacement during the appropriate phase of the build process.

The net effect is the same, it just makes the replacement definition more explicit.  I made this change because eclipse was getting confused by defining two resource elements for the same folder, and by both including and excluding the same file (the filtering setting is ignored).

This change mainly benefits me right now, but will also benefit any other contributors for pwm who generate their eclipse projects using the maven command:
$ mvn eclipse:eclipse

@jrivard Please review and merge