### PR TITLE
Bug #941830 - [Enh] SSPR does not allow sending e-mails to multiple recipients simultaneously

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- container dependencies -->
         <dependency>

--- a/src/main/resources/password/pwm/i18n/Config.properties
+++ b/src/main/resources/password/pwm/i18n/Config.properties
@@ -146,5 +146,5 @@ VerificationMethodDetail_TOKEN=An Email and/or SMS token is sent to the user for
 VerificationMethodDetail_OTP=TOTP authentication.  Referred to on user screens as Mobile App Authentication.
 VerificationMethodDetail_REMOTE_RESPONSES=Utilize a configured web service for user response verification.   See @PwmSettingReference:external.remoteResponses.url@.
 VerificationMethodDetail_NAAF=Use NetIQ Advanced Authentication Framework for verification.
-
+Instructions_Edit_Email=Multiple email addresses can be provided, separated by commas.
 

--- a/src/main/webapp/public/resources/js/configeditor-settings.js
+++ b/src/main/webapp/public/resources/js/configeditor-settings.js
@@ -1766,9 +1766,10 @@ EmailTableHandler.instrumentRow = function(settingKey, localeName) {
     var settingData = PWM_SETTINGS['settings'][settingKey];
     var idPrefix = "setting-" + localeName + "-" + settingKey;
 
-    var editor = function(drawTextArea, type){
+    var editor = function(drawTextArea, type, instructions){
         UILibrary.stringEditorDialog({
             title:'Edit Value - ' + settingData['label'],
+            instructions: instructions,
             textarea:drawTextArea,
             value:PWM_VAR['clientSettingCache'][settingKey][localeName][type],
             completeFunction:function(value){
@@ -1781,8 +1782,8 @@ EmailTableHandler.instrumentRow = function(settingKey, localeName) {
     };
 
     UILibrary.addTextValueToElement('panel-to-' + idPrefix,PWM_VAR['clientSettingCache'][settingKey][localeName]['to']);
-    PWM_MAIN.addEventHandler('button-to-' + idPrefix,'click',function(){ editor(false,'to'); });
-    PWM_MAIN.addEventHandler('panel-to-' + idPrefix,'click',function(){ editor(false,'to'); });
+    PWM_MAIN.addEventHandler('button-to-' + idPrefix,'click',function(){ editor(false,'to',PWM_CONFIG.showString('Instructions_Edit_Email')); });
+    PWM_MAIN.addEventHandler('panel-to-' + idPrefix,'click',function(){ editor(false,'to',PWM_CONFIG.showString('Instructions_Edit_Email')); });
 
     UILibrary.addTextValueToElement('panel-from-' + idPrefix,PWM_VAR['clientSettingCache'][settingKey][localeName]['from']);
     PWM_MAIN.addEventHandler('button-from-' + idPrefix,'click',function(){ editor(false,'from'); });

--- a/src/main/webapp/public/resources/js/uilibrary.js
+++ b/src/main/webapp/public/resources/js/uilibrary.js
@@ -26,6 +26,7 @@ var UILibrary = {};
 UILibrary.stringEditorDialog = function(options){
     options = options === undefined ? {} : options;
     var title = 'title' in options ? options['title'] : 'Edit Value';
+    var instructions = 'instructions' in options ? options['instructions'] : null;
     var completeFunction = 'completeFunction' in options ? options['completeFunction'] : function() {alert('no string editor dialog complete function')};
     var regexString = 'regex' in options && options['regex'] ? options['regex'] : '.+';
     var initialValue = 'value' in options ? options['value'] : '';
@@ -36,6 +37,11 @@ UILibrary.stringEditorDialog = function(options){
     var text = '';
     text += '<div style="visibility: hidden;" id="panel-valueWarning"><span class="fa fa-warning message-error"></span>&nbsp;' + PWM_CONFIG.showString('Warning_ValueIncorrectFormat') + '</div>';
     text += '<br/>';
+
+    if (instructions != null) {
+        text += '<div id="panel-valueInstructions">&nbsp;' + options['instructions'] + '</div>';
+        text += '<br/>';
+    }
 
     if (textarea) {
         text += '<textarea style="max-width: 480px; width: 480px; height:300px; max-height:300px; overflow-y: auto" class="configStringInput" autofocus required id="addValueDialog_input"></textarea>';

--- a/src/test/java/javax/mail/internet/InternetAddressTest.java
+++ b/src/test/java/javax/mail/internet/InternetAddressTest.java
@@ -1,0 +1,52 @@
+package javax.mail.internet;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * Tests to ensure the email address parsing from javax.mail.internet.InternetAddress is what we
+ * expect.
+ */
+public class InternetAddressTest {
+    @Test(expected = Exception.class)
+    public void testParse_null() throws AddressException {
+        InternetAddress.parse(null, true);
+    }
+
+    @Test
+    public void testParse_empty() throws AddressException {
+        InternetAddress[] addresses = InternetAddress.parse("", true);
+        Assert.assertEquals(0, addresses.length);
+    }
+
+    @Test
+    public void testParse_single() throws AddressException {
+        InternetAddress[] addresses = InternetAddress.parse("fred@flintstones.tv");
+
+        Assert.assertEquals(1, addresses.length);
+        Assert.assertEquals("fred@flintstones.tv", addresses[0].getAddress());
+    }
+
+    @Test
+    public void testParse_multiple() throws AddressException {
+        InternetAddress[] addresses = InternetAddress.parse("fred@flintstones.tv,wilma@flinstones.tv, barney@flintstones.tv,   betty@flinstones.tv");
+
+        Assert.assertEquals(4, addresses.length);
+        Assert.assertEquals("fred@flintstones.tv", addresses[0].getAddress());
+        Assert.assertEquals("wilma@flinstones.tv", addresses[1].getAddress());
+        Assert.assertEquals("barney@flintstones.tv", addresses[2].getAddress());
+        Assert.assertEquals("betty@flinstones.tv", addresses[3].getAddress());
+    }
+
+    @Test
+    public void testParse_multipleWithCommasInName() throws AddressException {
+        InternetAddress[] addresses = InternetAddress.parse("fred@flintstones.tv,wilma@flinstones.tv, \"Rubble, Barney\"@flintstones.tv,   Betty Rubble <betty@flinstones.tv>");
+
+        Assert.assertEquals(4, addresses.length);
+        Assert.assertEquals("fred@flintstones.tv", addresses[0].getAddress());
+        Assert.assertEquals("wilma@flinstones.tv", addresses[1].getAddress());
+        Assert.assertEquals("\"Rubble, Barney\"@flintstones.tv", addresses[2].getAddress());
+        Assert.assertEquals("betty@flinstones.tv", addresses[3].getAddress());
+    }
+}

--- a/src/test/java/password/pwm/util/queue/EmailQueueManagerTest.java
+++ b/src/test/java/password/pwm/util/queue/EmailQueueManagerTest.java
@@ -1,0 +1,49 @@
+package password.pwm.util.queue;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+
+import junit.framework.Assert;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import password.pwm.AppProperty;
+import password.pwm.bean.EmailItemBean;
+import password.pwm.config.Configuration;
+
+public class EmailQueueManagerTest {
+    @Test
+    public void testConvertEmailItemToMessage() throws MessagingException, IOException {
+        EmailQueueManager emailQueueManager = new EmailQueueManager();
+
+        Configuration config = Mockito.mock(Configuration.class);
+        Mockito.when(config.readAppProperty(AppProperty.SMTP_SUBJECT_ENCODING_CHARSET)).thenReturn("UTF8");
+
+        EmailItemBean emailItemBean = new EmailItemBean("fred@flintstones.tv, barney@flintstones.tv", "bedrock-admin@flintstones.tv", "Test Subject", "bodyPlain", "bodyHtml");
+
+        List<Message> messages = emailQueueManager.convertEmailItemToMessages(emailItemBean, config);
+        Assert.assertEquals(2, messages.size());
+
+        Message message = messages.get(0);
+        Assert.assertEquals(new InternetAddress("fred@flintstones.tv"), message.getRecipients(Message.RecipientType.TO)[0]);
+        Assert.assertEquals(new InternetAddress("bedrock-admin@flintstones.tv"), message.getFrom()[0]);
+        Assert.assertEquals("Test Subject", message.getSubject());
+        String content = IOUtils.toString(message.getInputStream());
+        Assert.assertTrue(content.contains("bodyPlain"));
+        Assert.assertTrue(content.contains("bodyHtml"));
+
+        message = messages.get(1);
+        Assert.assertEquals(new InternetAddress("barney@flintstones.tv"), message.getRecipients(Message.RecipientType.TO)[0]);
+        Assert.assertEquals(new InternetAddress("bedrock-admin@flintstones.tv"), message.getFrom()[0]);
+        Assert.assertEquals("Test Subject", message.getSubject());
+        content = IOUtils.toString(message.getInputStream());
+        Assert.assertTrue(content.contains("bodyPlain"));
+        Assert.assertTrue(content.contains("bodyHtml"));
+    }
+}


### PR DESCRIPTION
I updated the code to allow for supplying multiple email addresses in the "To:" field, separated by commas.  The EmailQueueManager loops through each email separately so all recipients don't see each other.  I also added some help text to the dialog explaining: "Multiple email addresses can be provided, separated by commas."

@jrivard Please review and merge