### PR TITLE
Getting rid of shell error messages

### DIFF
--- a/src/main/webapp/WEB-INF/command.sh
+++ b/src/main/webapp/WEB-INF/command.sh
@@ -12,14 +12,7 @@ exit 1
 fi
 
 JAVA_OPTS=-Xmx1024m
-for i in lib/*.jar ; do
- if [ "$CLASSPATH" == "" ]; then
-   CLASSPATH=$i
- else
-   CLASSPATH=$CLASSPATH:$i
- fi
-done
-CLASSPATH=$CLASSPATH:classes
+CLASSPATH=lib/*:classes
 
 $JAVA_HOME/bin/java $JAVA_OPTS -cp $CLASSPATH password.pwm.util.cli.MainClass $1 $2 $3 $4 $5 $6 $7 $8 $9
 


### PR DESCRIPTION
Currently, we get the following error messages when building the CLASSPATH:
./command.sh: 19: [: unexpected operator

We can use Java's wildcard mechanism for finding all the jars in a folder instead.

@jrivard Please review and merge