### PR TITLE
Allow tomcat port to be changed from a maven property, if port 8080 i…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <build.number>0</build.number>  <!-- default in case not set on command line -->
         <build.revision>0</build.revision>  <!-- default in case not set on command line -->
+        <tomcat7.port>8080</tomcat7.port> <!-- This allows us to run: "mvn tomcat7:run", then we can open a browser to: http://localhost:8080/pwm, change to suit -->
     </properties>
 
     <profiles>
@@ -104,6 +105,9 @@
                 <groupId>org.apache.tomcat.maven</groupId>
                 <artifactId>tomcat7-maven-plugin</artifactId>
                 <version>2.2</version>
+                <configuration>
+                    <port>${tomcat7.port}</port>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…s taken

Since there is a property that can be used to change the default port, we might as well use it and place the port number at the top of the maven pom file for easier access.