### PR TITLE
ExportHttpsKeyStore requires an alias in startup.sh for docker

### DIFF
--- a/supplemental/docker/readme.txt
+++ b/supplemental/docker/readme.txt
@@ -1,6 +1,6 @@
-This docker build script and artifacts can be used to create a SSPR docker image.
+This docker build script and artifacts can be used to create a PWM docker image.
 
-1) Place desired sspr.war in this directory (it must be named sspr.war)
+1) Place desired pwm.war in this directory (it must be named pwm.war)
 2) Execute the make-docker-image.sh script
 
 This script will create a docker image tagged as 'pwm', and also create a pwm-docker-image.tar.gz save of the image.
@@ -8,16 +8,16 @@ This script will create a docker image tagged as 'pwm', and also create a pwm-do
 Docker image usage notes:
 
 --Load docker image from file
-docker load --input-file=pwm-docker-image.tar.gz
+docker load --input=pwm-docker-image.tar.gz
 
 --Create docker container and run--
-docker run -d --name <container name> -p 8443:8443 sspr
+docker run -d --name <container name> -p 8443:8443 pwm
 
 This will set the https port to 8443.  You can also manage the exposed configuration volume of /config if you want to preserve
 the /config directory when you destroy/create the container in the future.  The docker image will place all of it's configuration
 and runtime data in the /config volume.
 
---Run SSPR shell inside the container--
+--Run PWM shell inside the container--
 To reset the https config, unlock the config or other commands, you can execute the PWM shell inside the running docker container:
 
 docker exec -it <container name> /appliance/shell.sh

--- a/supplemental/docker/startup.sh
+++ b/supplemental/docker/startup.sh
@@ -15,7 +15,7 @@ chmod a+x command.sh
 
 # update the https certificate file used by tomcat
 rm /appliance/https-cert
-./command.sh ExportHttpsKeyStore /appliance/https-cert password
+./command.sh ExportHttpsKeyStore /appliance/https-cert https password
 
 # update the https configuration used by tomcat
 rm $TOMCAT_HOME/conf/server.xml


### PR DESCRIPTION
ExportHttpsKeyStore requires an alias in startup.sh for docker - also fixed some readme references.