### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/password/pwm/config/Configuration.java
+++ b/src/main/java/password/pwm/config/Configuration.java
@@ -65,6 +65,10 @@ public class Configuration implements Serializable, SettingReader {
 
     private DataCache dataCache = new DataCache();
 
+    private PwmSecurityKey tempInstanceKey = null;
+
+    private Convenience helper = new Convenience();
+
     // --------------------------- CONSTRUCTORS ---------------------------
 
     public Configuration(final StoredConfigurationImpl storedConfiguration) {
@@ -502,7 +506,6 @@ public class Configuration implements Serializable, SettingReader {
         return storedConfiguration.readConfigProperty(ConfigurationProperty.NOTES);
     }
 
-    private PwmSecurityKey tempInstanceKey = null;
     public PwmSecurityKey getSecurityKey() throws PwmUnrecoverableException {
         final PasswordData configValue = readSettingAsPassword(PwmSetting.PWM_SECURITY_KEY);
 
@@ -653,8 +656,6 @@ public class Configuration implements Serializable, SettingReader {
         }
         return property.getDefaultValue();
     }
-
-    private Convenience helper = new Convenience();
 
     public Convenience helper() {
         return helper;

--- a/src/main/java/password/pwm/config/FormConfiguration.java
+++ b/src/main/java/password/pwm/config/FormConfiguration.java
@@ -60,6 +60,13 @@ public class FormConfiguration implements Serializable {
     private String javascript;
     private Map<String,String> selectOptions = Collections.emptyMap();
 
+// --------------------------- CONSTRUCTORS ---------------------------
+
+    public FormConfiguration() {
+        labels = Collections.singletonMap("","");
+        regexErrors = Collections.singletonMap("","");
+    }
+
 // -------------------------- STATIC METHODS --------------------------
 
     public static FormConfiguration parseOldConfigString(final String config)
@@ -137,13 +144,6 @@ public class FormConfiguration implements Serializable {
                 throw new PwmOperationalException(new ErrorInformation(PwmError.CONFIG_FORMAT_ERROR,null,new String[]{" field '" + this.getName() + " ' is type select, but no select options are defined"}));
             }
         }
-    }
-
-// --------------------------- CONSTRUCTORS ---------------------------
-
-    public FormConfiguration() {
-        labels = Collections.singletonMap("","");
-        regexErrors = Collections.singletonMap("","");
     }
 
 // --------------------- GETTER / SETTER METHODS ---------------------

--- a/src/main/java/password/pwm/config/profile/PwmPasswordPolicy.java
+++ b/src/main/java/password/pwm/config/profile/PwmPasswordPolicy.java
@@ -71,6 +71,23 @@ public class PwmPasswordPolicy implements Profile,Serializable {
     private List<UserPermission> userPermissions;
     private String ruleText;
 
+    private PwmPasswordPolicy(
+            final Map<String, String> policyMap,
+            final ChaiPasswordPolicy chaiPasswordPolicy
+    ) {
+        if (policyMap != null) {
+            this.policyMap.putAll(policyMap);
+        }
+        if (chaiPasswordPolicy != null) {
+            if (Boolean.parseBoolean(chaiPasswordPolicy.getValue(ChaiPasswordRule.ADComplexity))) {
+                this.policyMap.put(PwmPasswordRule.ADComplexityLevel.getKey(), ADPolicyComplexity.AD2003.toString());
+            } else if (Boolean.parseBoolean(chaiPasswordPolicy.getValue(ChaiPasswordRule.ADComplexity2008))) {
+                this.policyMap.put(PwmPasswordRule.ADComplexityLevel.getKey(), ADPolicyComplexity.AD2008.toString());
+            }
+        }
+        this.chaiPasswordPolicy = chaiPasswordPolicy;
+    }
+
     public static PwmPasswordPolicy createPwmPasswordPolicy(
             final Map<String, String> policyMap,
             final ChaiPasswordPolicy chaiPasswordPolicy
@@ -104,24 +121,6 @@ public class PwmPasswordPolicy implements Profile,Serializable {
 
     public static PwmPasswordPolicy defaultPolicy() {
         return defaultPolicy;
-    }
-
-
-    private PwmPasswordPolicy(
-            final Map<String, String> policyMap,
-            final ChaiPasswordPolicy chaiPasswordPolicy
-    ) {
-        if (policyMap != null) {
-            this.policyMap.putAll(policyMap);
-        }
-        if (chaiPasswordPolicy != null) {
-            if (Boolean.parseBoolean(chaiPasswordPolicy.getValue(ChaiPasswordRule.ADComplexity))) {
-                this.policyMap.put(PwmPasswordRule.ADComplexityLevel.getKey(), ADPolicyComplexity.AD2003.toString());
-            } else if (Boolean.parseBoolean(chaiPasswordPolicy.getValue(ChaiPasswordRule.ADComplexity2008))) {
-                this.policyMap.put(PwmPasswordRule.ADComplexityLevel.getKey(), ADPolicyComplexity.AD2008.toString());
-            }
-        }
-        this.chaiPasswordPolicy = chaiPasswordPolicy;
     }
 
     @Override

--- a/src/main/java/password/pwm/config/stored/StoredConfigurationImpl.java
+++ b/src/main/java/password/pwm/config/stored/StoredConfigurationImpl.java
@@ -63,6 +63,13 @@ public class StoredConfigurationImpl implements Serializable, StoredConfiguratio
     private boolean locked = false;
     private boolean setting_writeLabels = true;
     private final ReentrantReadWriteLock domModifyLock = new ReentrantReadWriteLock();
+    private PwmSecurityKey cachedKey = null;
+
+    public StoredConfigurationImpl() throws PwmUnrecoverableException {
+        ConfigurationCleaner.cleanup(this);
+        final String createTime = PwmConstants.DEFAULT_DATETIME_FORMAT.format(new Date());
+        document.getRootElement().setAttribute(XML_ATTRIBUTE_CREATE_TIME,createTime);
+    }
 
 // -------------------------- STATIC METHODS --------------------------
 
@@ -146,13 +153,6 @@ public class StoredConfigurationImpl implements Serializable, StoredConfiguratio
             }
         }
     }
-
-    public StoredConfigurationImpl() throws PwmUnrecoverableException {
-        ConfigurationCleaner.cleanup(this);
-        final String createTime = PwmConstants.DEFAULT_DATETIME_FORMAT.format(new Date());
-        document.getRootElement().setAttribute(XML_ATTRIBUTE_CREATE_TIME,createTime);
-    }
-
 
     @Override
     public String readConfigProperty(final ConfigurationProperty propertyName) {
@@ -1201,7 +1201,6 @@ public class StoredConfigurationImpl implements Serializable, StoredConfiguratio
         return changeLog.changeLogAsDebugString(locale, asHtml);
     }
 
-    private PwmSecurityKey cachedKey = null;
     public PwmSecurityKey getKey() throws PwmUnrecoverableException {
         if (cachedKey == null) {
             cachedKey = new PwmSecurityKey(createTime() + "StoredConfiguration");

--- a/src/main/java/password/pwm/config/value/PasswordValue.java
+++ b/src/main/java/password/pwm/config/value/PasswordValue.java
@@ -44,10 +44,10 @@ import java.util.Locale;
 public class PasswordValue implements StoredValue {
     private PasswordData value;
 
+    boolean requiresStoredUpdate;
+
     PasswordValue() {
     }
-
-    boolean requiresStoredUpdate;
 
     public PasswordValue(PasswordData passwordData) {
         value = passwordData;

--- a/src/main/java/password/pwm/config/value/PrivateKeyValue.java
+++ b/src/main/java/password/pwm/config/value/PrivateKeyValue.java
@@ -49,6 +49,10 @@ public class PrivateKeyValue extends AbstractValue {
 
     private PrivateKeyCertificate privateKeyCertificate;
 
+    public PrivateKeyValue(PrivateKeyCertificate privateKeyCertificate) {
+        this.privateKeyCertificate = privateKeyCertificate;
+    }
+
     public static StoredValue.StoredValueFactory factory() {
         return new StoredValue.StoredValueFactory() {
             public PrivateKeyValue fromXmlElement(final Element settingElement, final PwmSecurityKey key) {
@@ -94,10 +98,6 @@ public class PrivateKeyValue extends AbstractValue {
                 return new X509CertificateValue(new X509Certificate[0]);
             }
         };
-    }
-
-    public PrivateKeyValue(PrivateKeyCertificate privateKeyCertificate) {
-        this.privateKeyCertificate = privateKeyCertificate;
     }
 
 

--- a/src/main/java/password/pwm/config/value/X509CertificateValue.java
+++ b/src/main/java/password/pwm/config/value/X509CertificateValue.java
@@ -43,6 +43,20 @@ public class X509CertificateValue extends AbstractValue implements StoredValue {
     private static final PwmLogger LOGGER = PwmLogger.forClass(X509CertificateValue.class);
     private X509Certificate[] certificates;
 
+    public X509CertificateValue(X509Certificate[] certificates) {
+        if (certificates == null) {
+            throw new NullPointerException("certificates cannot be null");
+        }
+        this.certificates = certificates;
+    }
+
+    public X509CertificateValue(Collection<X509Certificate> certificates) {
+        if (certificates == null) {
+            throw new NullPointerException("certificates cannot be null");
+        }
+        this.certificates = certificates.toArray(new X509Certificate[certificates.size()]);
+    }
+
     public static StoredValueFactory factory() {
         return new StoredValueFactory() {
             public X509CertificateValue fromXmlElement(final Element settingElement, final PwmSecurityKey key) {
@@ -65,22 +79,8 @@ public class X509CertificateValue extends AbstractValue implements StoredValue {
         };
     }
 
-    public X509CertificateValue(X509Certificate[] certificates) {
-        if (certificates == null) {
-            throw new NullPointerException("certificates cannot be null");
-        }
-        this.certificates = certificates;
-    }
-
     public boolean hasCertificates() {
         return certificates != null && certificates.length > 0;
-    }
-
-    public X509CertificateValue(Collection<X509Certificate> certificates) {
-        if (certificates == null) {
-            throw new NullPointerException("certificates cannot be null");
-        }
-        this.certificates = certificates.toArray(new X509Certificate[certificates.size()]);
     }
 
 

--- a/src/main/java/password/pwm/http/PwmRequest.java
+++ b/src/main/java/password/pwm/http/PwmRequest.java
@@ -74,6 +74,20 @@ public class PwmRequest extends PwmHttpRequestWrapper implements Serializable {
 
     private final Set<PwmRequestFlag> flags = new HashSet<>();
 
+    private PwmRequest(
+            final HttpServletRequest httpServletRequest,
+            final HttpServletResponse httpServletResponse,
+            final PwmApplication pwmApplication,
+            final PwmSession pwmSession
+    )
+            throws PwmUnrecoverableException
+    {
+        super(httpServletRequest, pwmApplication.getConfig());
+        this.pwmResponse = new PwmResponse(httpServletResponse, this, pwmApplication.getConfig());
+        this.pwmSession = pwmSession;
+        this.pwmApplication = pwmApplication;
+    }
+
     public static PwmRequest forRequest(
             HttpServletRequest request,
             HttpServletResponse response
@@ -88,20 +102,6 @@ public class PwmRequest extends PwmHttpRequestWrapper implements Serializable {
             request.setAttribute(PwmRequest.Attribute.PwmRequest.toString(), pwmRequest);
         }
         return pwmRequest;
-    }
-
-    private PwmRequest(
-            final HttpServletRequest httpServletRequest,
-            final HttpServletResponse httpServletResponse,
-            final PwmApplication pwmApplication,
-            final PwmSession pwmSession
-    )
-            throws PwmUnrecoverableException
-    {
-        super(httpServletRequest, pwmApplication.getConfig());
-        this.pwmResponse = new PwmResponse(httpServletResponse, this, pwmApplication.getConfig());
-        this.pwmSession = pwmSession;
-        this.pwmApplication = pwmApplication;
     }
 
     public PwmApplication getPwmApplication()

--- a/src/main/java/password/pwm/http/PwmSession.java
+++ b/src/main/java/password/pwm/http/PwmSession.java
@@ -63,14 +63,6 @@ public class PwmSession implements Serializable {
 
     private transient SessionManager sessionManager;
 
-    public static PwmSession createPwmSession(final PwmApplication pwmApplication)
-            throws PwmUnrecoverableException
-    {
-        synchronized (creationLock) {
-            return new PwmSession(pwmApplication);
-        }
-    }
-
 
     private PwmSession(final PwmApplication pwmApplication)
             throws PwmUnrecoverableException
@@ -103,6 +95,14 @@ public class PwmSession implements Serializable {
 
         settings.restKeyLength = Integer.parseInt(pwmApplication.getConfig().readAppProperty(AppProperty.SECURITY_WS_REST_CLIENT_KEY_LENGTH));
         LOGGER.trace(this,"created new session");
+    }
+
+    public static PwmSession createPwmSession(final PwmApplication pwmApplication)
+            throws PwmUnrecoverableException
+    {
+        synchronized (creationLock) {
+            return new PwmSession(pwmApplication);
+        }
     }
 
 

--- a/src/main/java/password/pwm/http/servlet/AbstractPwmServlet.java
+++ b/src/main/java/password/pwm/http/servlet/AbstractPwmServlet.java
@@ -46,6 +46,8 @@ public abstract class AbstractPwmServlet extends HttpServlet implements PwmServl
 
     private static final PwmLogger LOGGER = PwmLogger.forClass(AbstractPwmServlet.class);
 
+    public static final Collection<HttpMethod> GET_AND_POST_METHODS;
+
     public void doGet(
             final HttpServletRequest req,
             final HttpServletResponse resp
@@ -254,8 +256,6 @@ public abstract class AbstractPwmServlet extends HttpServlet implements PwmServl
     public interface ProcessAction {
         Collection<HttpMethod> permittedMethods();
     }
-
-    public static final Collection<HttpMethod> GET_AND_POST_METHODS;
 
     static {
         final HashSet<HttpMethod> methods = new HashSet<>();

--- a/src/main/java/password/pwm/http/tag/url/PwmThemeURL.java
+++ b/src/main/java/password/pwm/http/tag/url/PwmThemeURL.java
@@ -7,11 +7,11 @@ public enum PwmThemeURL {
     MOBILE_THEME_URL(ResourceFileServlet.THEME_CSS_MOBILE_PATH),
     CONFIG_THEME_URL(ResourceFileServlet.THEME_CSS_CONFIG_PATH),;
 
+    private final String cssName;
+
     PwmThemeURL(String cssName) {
         this.cssName = cssName;
     }
-
-    private final String cssName;
 
     public String token() {
         return "%" + this.toString() + "%";

--- a/src/main/java/password/pwm/i18n/Message.java
+++ b/src/main/java/password/pwm/i18n/Message.java
@@ -163,12 +163,12 @@ public enum Message implements PwmDisplayBundle {
 
     private final Message pluralMessage;
 
-    public static String getLocalizedMessage(final Locale locale, final Message message, final Configuration config, final String... fieldValue) {
-        return LocaleHelper.getLocalizedMessage(locale, message.getKey(), config, Message.class, fieldValue);
-    }
-
     Message(final Message pluralMessage) {
         this.pluralMessage = pluralMessage;
+    }
+
+    public static String getLocalizedMessage(final Locale locale, final Message message, final Configuration config, final String... fieldValue) {
+        return LocaleHelper.getLocalizedMessage(locale, message.getKey(), config, Message.class, fieldValue);
     }
 
     public Message getPluralMessage() {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 75 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava