### PR TITLE
squid:S1197 - Array designators "[]" should be on the type, not the variable

### DIFF
--- a/src/main/java/password/pwm/bean/PrivateKeyCertificate.java
+++ b/src/main/java/password/pwm/bean/PrivateKeyCertificate.java
@@ -30,7 +30,7 @@ public class PrivateKeyCertificate implements Serializable {
     final private X509Certificate[] certificates;
     final private PrivateKey key;
 
-    public PrivateKeyCertificate(X509Certificate certificates[], PrivateKey key) {
+    public PrivateKeyCertificate(X509Certificate[] certificates, PrivateKey key) {
         this.certificates = certificates;
         this.key = key;
     }

--- a/src/main/java/password/pwm/http/filter/GZIPFilter.java
+++ b/src/main/java/password/pwm/http/filter/GZIPFilter.java
@@ -182,12 +182,12 @@ public class GZIPFilter implements Filter {
         }
 
         @Override
-        public void write(final byte b[]) throws IOException {
+        public void write(final byte[] b) throws IOException {
             write(b, 0, b.length);
         }
 
         @Override
-        public void write(final byte b[], final int off, final int len) throws IOException {
+        public void write(final byte[] b, final int off, final int len) throws IOException {
             if (!open.get()) {
                 throw new IOException("Stream closed!");
             }

--- a/src/main/java/password/pwm/svc/event/SyslogAuditService.java
+++ b/src/main/java/password/pwm/svc/event/SyslogAuditService.java
@@ -273,7 +273,7 @@ public class SyslogAuditService {
                 throw new IllegalArgumentException("input cannot be null");
             }
 
-            final String parts[] = input.split(",");
+            final String[] parts = input.split(",");
             if (parts.length != 3) {
                 throw new IllegalArgumentException("input must have three comma separated parts.");
             }

--- a/src/main/java/password/pwm/svc/token/LdapTokenMachine.java
+++ b/src/main/java/password/pwm/svc/token/LdapTokenMachine.java
@@ -92,7 +92,7 @@ class LdapTokenMachine implements TokenMachine {
             final UserDataReader userDataReader = LdapUserDataReader.appProxiedReader(pwmApplication, user);
             final String tokenAttributeValue = userDataReader.readStringAttribute(tokenAttribute);
             if (tokenAttribute != null && tokenAttributeValue.length() > 0) {
-                final String splitString[] = tokenAttributeValue.split(KEY_VALUE_DELIMITER);
+                final String[] splitString = tokenAttributeValue.split(KEY_VALUE_DELIMITER);
                 if (splitString.length != 2) {
                     final String errorMsg = "error parsing ldap stored token, not enough delimited values";
                     final ErrorInformation errorInformation = new ErrorInformation(PwmError.ERROR_TOKEN_INCORRECT,errorMsg);

--- a/src/main/java/password/pwm/util/Helper.java
+++ b/src/main/java/password/pwm/util/Helper.java
@@ -77,8 +77,8 @@ public class
      * @param in byte[] buffer to convert to string format
      * @return result String buffer in String format
      */
-    public static String byteArrayToHexString(final byte in[]) {
-        final String pseudo[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"};
+    public static String byteArrayToHexString(final byte[] in) {
+        final String[] pseudo = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"};
 
         if (in == null || in.length <= 0) {
             return "";

--- a/src/main/java/password/pwm/util/operations/cr/NMASCrOperator.java
+++ b/src/main/java/password/pwm/util/operations/cr/NMASCrOperator.java
@@ -501,7 +501,7 @@ public class NMASCrOperator implements CrOperator {
                 super(lcmenvironment, lcmregistry);
             }
 
-            public void handle(final Callback callbacks[]) throws UnsupportedCallbackException
+            public void handle(final Callback[] callbacks) throws UnsupportedCallbackException
             {
                 for (final Callback callback : callbacks) {
                     if (callback instanceof NMASCompletionCallback) {

--- a/src/main/java/password/pwm/util/otp/OTPPamUtil.java
+++ b/src/main/java/password/pwm/util/otp/OTPPamUtil.java
@@ -47,7 +47,7 @@ public class OTPPamUtil {
     public static List<String> splitLines(String text) {
         List<String> list = new ArrayList<>();
         if (text != null) {
-            String lines[] = text.split("\r?\n|\r");
+            String[] lines = text.split("\r?\n|\r");
             list.addAll(Arrays.asList(lines));
         }
         return list;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1197 - Array designators "[]" should be on the type, not the variable.
This pull request removes 45 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
Please let me know if you have any questions.
George Kankava