### PR TITLE
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/src/main/java/password/pwm/config/value/StringValue.java
+++ b/src/main/java/password/pwm/config/value/StringValue.java
@@ -82,7 +82,7 @@ public class StringValue extends AbstractValue implements StoredValue {
         final Pattern pattern = pwmSetting.getRegExPattern();
         if (pattern != null && value != null) {
             final Matcher matcher = pattern.matcher(value);
-            if (value != null && value.length() > 0 && !matcher.matches()) {
+            if (value.length() > 0 && !matcher.matches()) {
                 return Collections.singletonList("incorrect value format for value '" + value + "'");
             }
         }

--- a/src/main/java/password/pwm/http/state/CryptoRequestBeanImpl.java
+++ b/src/main/java/password/pwm/http/state/CryptoRequestBeanImpl.java
@@ -109,7 +109,7 @@ class CryptoRequestBeanImpl implements SessionBeanProvider {
             return;
         }
         try {
-            if (pwmRequest != null && pwmRequest.getPwmResponse() != null) {
+            if (pwmRequest.getPwmResponse() != null) {
                 final Map<Class<? extends PwmSessionBean>,PwmSessionBean> beansInRequest = getRequestBeanMap(pwmRequest);
                 if (beansInRequest != null) {
                     for (final Class<? extends PwmSessionBean> theClass : beansInRequest.keySet()) {

--- a/src/main/java/password/pwm/http/tag/ErrorMessageTag.java
+++ b/src/main/java/password/pwm/http/tag/ErrorMessageTag.java
@@ -81,10 +81,8 @@ public class ErrorMessageTag extends PwmAbstractTag {
 
                 outputMsg = outputMsg.replace("\n","<br/>");
 
-                if (pwmRequest != null) {
-                    final MacroMachine macroMachine = pwmRequest.getPwmSession().getSessionManager().getMacroMachine(pwmApplication);
-                    outputMsg = macroMachine.expandMacros(outputMsg);
-                }
+                final MacroMachine macroMachine = pwmRequest.getPwmSession().getSessionManager().getMacroMachine(pwmApplication);
+                outputMsg = macroMachine.expandMacros(outputMsg);
 
                 pageContext.getOut().write(outputMsg);
             }

--- a/src/main/java/password/pwm/ws/client/novell/pwdmgt/ForgotPasswordConfWSBean.java
+++ b/src/main/java/password/pwm/ws/client/novell/pwdmgt/ForgotPasswordConfWSBean.java
@@ -86,17 +86,16 @@ public class ForgotPasswordConfWSBean  implements java.io.Serializable {
 
     private java.lang.Object __equalsCalc = null;
     public synchronized boolean equals(java.lang.Object obj) {
+        if (obj == null) return false;
         if (!(obj instanceof ForgotPasswordConfWSBean)) return false;
         ForgotPasswordConfWSBean other = (ForgotPasswordConfWSBean) obj;
-        if (obj == null) return false;
         if (this == obj) return true;
         if (__equalsCalc != null) {
             return (__equalsCalc == obj);
         }
         __equalsCalc = obj;
         boolean _equals;
-        _equals = true && 
-            ((this.configuredRtnLink==null && other.getConfiguredRtnLink()==null) || 
+        _equals = ((this.configuredRtnLink==null && other.getConfiguredRtnLink()==null) ||
              (this.configuredRtnLink!=null &&
               this.configuredRtnLink.equals(other.getConfiguredRtnLink()))) &&
             this.showReturnLink == other.isShowReturnLink();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
This pull request removes 75 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2583
Please let me know if you have any questions.
George Kankava