### PR TITLE
corrections for cas filter to start properly again

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -88,10 +88,6 @@
             <param-value>https://pwm.localdomain.local:8443</param-value>
         </init-param>
         <init-param>
-            <param-name>renew</param-name>
-            <param-value>false</param-value>
-        </init-param>
-        <init-param>
             <param-name>gateway</param-name>
             <param-value>false</param-value>
         </init-param>


### PR DESCRIPTION
without these changes the cas filters do not start and the app cannot be deployed (SEVERE: filterStart)