### PR TITLE
Performance related bug fixes

### DIFF
--- a/src/main/angular/src/peoplesearch/orgchart-search.component.html
+++ b/src/main/angular/src/peoplesearch/orgchart-search.component.html
@@ -3,6 +3,7 @@
     <mf-auto-complete search-text="$ctrl.query"
                       on-search-text-change="$ctrl.onSearchTextChange(value)"
                       search="$ctrl.autoCompleteSearch(query)"
+                      input-debounce="$ctrl.inputDebounce"
                       item-selected="$ctrl.onAutoCompleteItemSelected(person)"
                       item="person">
         <content-template>

--- a/src/main/angular/src/peoplesearch/orgchart-search.component.ts
+++ b/src/main/angular/src/peoplesearch/orgchart-search.component.ts
@@ -85,19 +85,25 @@ export default class OrgChartSearchComponent {
                 // Override personId in case it was undefined
                 personId = orgChartData.self.userKey;
 
-                self.$q
-                    .all({
-                        directReports: self.peopleService.getDirectReports(personId),
-                        managementChain: self.peopleService.getManagementChain(personId),
-                        person: self.peopleService.getPerson(personId)
-                    })
-                    .then(
-                        (data) => {
-                            self.$scope.$evalAsync(() => {
-                                self.directReports = data['directReports'];
-                                self.managementChain = data['managementChain'];
-                                self.person = data['person'];
-                            });
+                self.peopleService.getPerson(personId)
+                    .then((person: Person) => {
+                            self.person = person;
+                        },
+                        (error) => {
+                            // TODO: handle error
+                        });
+
+                self.peopleService.getManagementChain(personId)
+                    .then((managementChain: Person[]) => {
+                            self.managementChain = managementChain;
+                        },
+                        (error) => {
+                            // TODO: handle error
+                        });
+
+                self.peopleService.getDirectReports(personId)
+                    .then((directReports: Person[]) => {
+                            self.directReports = directReports;
                         },
                         (error) => {
                             // TODO: handle error

--- a/src/main/angular/src/peoplesearch/orgchart-search.component.ts
+++ b/src/main/angular/src/peoplesearch/orgchart-search.component.ts
@@ -61,12 +61,12 @@ export default class OrgChartSearchComponent {
                 private peopleService: IPeopleService,
                 private pwmService: IPwmService) {
         this.searchTextLocalStorageKey = this.localStorageService.keys.SEARCH_TEXT;
+        this.inputDebounce = this.pwmService.ajaxTypingWait;
     }
 
     $onInit(): void {
         const self = this;
 
-        this.inputDebounce = this.pwmService.ajaxTypingWait;
         this.configService.photosEnabled().then(
             (photosEnabled: boolean) => {
                 this.photosEnabled = photosEnabled;

--- a/src/main/angular/src/peoplesearch/peoplesearch-base.component.ts
+++ b/src/main/angular/src/peoplesearch/peoplesearch-base.component.ts
@@ -55,6 +55,8 @@ abstract class PeopleSearchBaseComponent {
                 protected pwmService: IPwmService) {
         this.searchTextLocalStorageKey = this.localStorageService.keys.SEARCH_TEXT;
         this.searchViewLocalStorageKey = this.localStorageService.keys.SEARCH_VIEW;
+
+        this.inputDebounce = this.pwmService.ajaxTypingWait;
     }
 
     getMessage(): string {
@@ -200,8 +202,6 @@ abstract class PeopleSearchBaseComponent {
     }
 
     protected initialize(): void {
-        this.inputDebounce = this.pwmService.ajaxTypingWait;
-
         // Determine whether org-chart should appear
         this.configService.orgChartEnabled().then((orgChartEnabled: boolean) => {
             this.orgChartEnabled = orgChartEnabled;


### PR DESCRIPTION
Two bugs are addressed:

1. OrgChartSearchComponent data downloading slowly has been addressed by not waiting for all org chart data to load before display content.

2. OrgChartSearchComponent's AutoCompleteComponent was not configured to use a debounce. This led to searches with large payloads completing well after typing had stopped. The old results would then show in place of the intended results.