### PR TITLE
Fix - Error when set localdb as token storage

### DIFF
--- a/src/main/java/password/pwm/util/localdb/AbstractJDBC_LocalDB.java
+++ b/src/main/java/password/pwm/util/localdb/AbstractJDBC_LocalDB.java
@@ -84,7 +84,7 @@ public abstract class AbstractJDBC_LocalDB implements LocalDBProvider {
                 final Instant startTime = Instant.now();
                 final StringBuilder sqlString = new StringBuilder();
                 sqlString.append("CREATE table ").append(db.toString()).append(" (").append("\n");
-                sqlString.append("  " + KEY_COLUMN + " VARCHAR(").append(WIDTH_KEY).append(") NOT NULL PRIMARY KEY,").append("\n");
+                sqlString.append("  " + KEY_COLUMN + " VARCHAR(256).append(WIDTH_KEY).append(") NOT NULL PRIMARY KEY,").append("\n");
                 sqlString.append("  " + VALUE_COLUMN + " CLOB");
                 sqlString.append("\n");
                 sqlString.append(")").append("\n");


### PR DESCRIPTION
Hi, 
This pull request fix this issue : Error when set localdb as token storage : https://github.com/pwm-project/pwm/issues/149
The default VARCHAR size is too small (128), when you use : "Public > Forgotten Password > Settings > Response Write Location > Database". This PR set all VARCHAR with size of 256. 
Thanks, 
Max.