### PR TITLE
Remove duplicate checks from Checkstyle configuration

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -228,11 +228,6 @@
         <!--
         <module name="AvoidNestedBlocks"/>
         -->
-        <module name="EmptyBlock">
-            <property name="option" value="TEXT"/>
-            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
-        </module>
-
 
 
         <!-- Checks for common coding problems               -->
@@ -302,7 +297,6 @@
         <module name="EqualsAvoidNull"/>
 
         <module name="MutableException"/>
-        <module name="OuterTypeFilename"/>
         <module name="TodoComment"/>
         <module name="NoLineWrap"/>
         <module name="OneTopLevelClass"/>


### PR DESCRIPTION
There were two duplicated checks in the Checkstyle configuration file which did not provide any useful information but just increased the overhead of Checkstyle. This PR removes them both.

Also, Checkstyle is now at version 8.0 and you are currently using version 7.2. I can help with updating to Checkstyle's latest version and clean up the current configuration file more, if you want.

Let me know.
