### PR TITLE
avoid sending token if SMS/Mail is null; fixes #252 and #253

### DIFF
--- a/server/src/main/java/password/pwm/http/servlet/UpdateProfileServlet.java
+++ b/server/src/main/java/password/pwm/http/servlet/UpdateProfileServlet.java
@@ -643,7 +643,7 @@ public class UpdateProfileServlet extends ControlledPwmServlet {
 
         if (updateAttributesProfile.readSettingAsBoolean(PwmSetting.UPDATE_PROFILE_EMAIL_VERIFICATION)) {
             final String emailAddressAttribute = ldapProfile.readSettingAsString(PwmSetting.EMAIL_USER_MAIL_ATTRIBUTE);
-            if (userFormData.containsKey(emailAddressAttribute)) {
+            if (userFormData.containsKey(emailAddressAttribute) && !userFormData.get(emailAddressAttribute).isEmpty()) {
                 ldapData = formDataFromLdap(pwmRequest, updateAttributesProfile);
                 if (userFormData.get(emailAddressAttribute) != null && !userFormData.get(emailAddressAttribute).equalsIgnoreCase(ldapData.get(emailAddressAttribute))) {
                     returnObj.add(TokenVerificationProgress.TokenChannel.EMAIL);
@@ -655,7 +655,7 @@ public class UpdateProfileServlet extends ControlledPwmServlet {
 
         if (updateAttributesProfile.readSettingAsBoolean(PwmSetting.UPDATE_PROFILE_SMS_VERIFICATION)) {
             final String phoneNumberAttribute = ldapProfile.readSettingAsString(PwmSetting.SMS_USER_PHONE_ATTRIBUTE);
-            if (userFormData.containsKey(phoneNumberAttribute)) {
+            if (userFormData.containsKey(phoneNumberAttribute) && !userFormData.get(phoneNumberAttribute).isEmpty()) {
                 if (ldapData == null) {
                     ldapData = formDataFromLdap(pwmRequest, updateAttributesProfile);
                 }

--- a/server/src/main/java/password/pwm/http/servlet/newuser/NewUserServlet.java
+++ b/server/src/main/java/password/pwm/http/servlet/newuser/NewUserServlet.java
@@ -237,7 +237,11 @@ public class NewUserServlet extends ControlledPwmServlet {
                 NewUserUtils.initializeToken(pwmRequest, newUserBean, TokenVerificationProgress.TokenChannel.EMAIL);
             }
 
-            if (!tokenVerificationProgress.getPassedTokens().contains(TokenVerificationProgress.TokenChannel.EMAIL)) {
+            if (!tokenVerificationProgress.getPassedTokens().contains(TokenVerificationProgress.TokenChannel.EMAIL)
+                    //if the token has been sent during the InitializeToken call, the issuedTokens member must contains the SMS key. If not, the token has not been sent (SMS number is null) and the verification phase should be ignored 
+                && tokenVerificationProgress.getIssuedTokens().contains(TokenVerificationProgress.TokenChannel.EMAIL)
+                ) 
+            {        
                 pwmRequest.forwardToJsp(JspUrl.NEW_USER_ENTER_CODE);
                 return;
             }
@@ -247,8 +251,11 @@ public class NewUserServlet extends ControlledPwmServlet {
             if (!newUserBean.getTokenVerificationProgress().getIssuedTokens().contains(TokenVerificationProgress.TokenChannel.SMS)) {
                 NewUserUtils.initializeToken(pwmRequest, newUserBean, TokenVerificationProgress.TokenChannel.SMS);
             }
-
-            if (!newUserBean.getTokenVerificationProgress().getPassedTokens().contains(TokenVerificationProgress.TokenChannel.SMS)) {
+            if (!newUserBean.getTokenVerificationProgress().getPassedTokens().contains(TokenVerificationProgress.TokenChannel.SMS)
+                //if the token has been sent during the InitializeToken call, the issuedTokens member must contains the SMS key. If not, the token has not been sent (SMS number is null) and the verification phase should be ignored 
+                && newUserBean.getTokenVerificationProgress().getIssuedTokens().contains(TokenVerificationProgress.TokenChannel.SMS)
+                ) 
+            {
                 pwmRequest.forwardToJsp(JspUrl.NEW_USER_ENTER_CODE);
                 return;
             }

--- a/server/src/main/java/password/pwm/http/servlet/newuser/NewUserUtils.java
+++ b/server/src/main/java/password/pwm/http/servlet/newuser/NewUserUtils.java
@@ -471,8 +471,17 @@ class NewUserUtils {
 
         switch (tokenType) {
             case SMS: {
-                final String toNum = tokenPayloadMap.get(pwmApplication.getConfig().getDefaultLdapProfile().readSettingAsString(PwmSetting.SMS_USER_PHONE_ATTRIBUTE));
-
+                String toNum = null;
+                final NewUserForm userForm = newUserBean.getNewUserForm();
+                if(userForm!=null && userForm.getFormData() != null && userForm.getFormData().get(pwmApplication.getConfig().getDefaultLdapProfile().readSettingAsString(PwmSetting.SMS_USER_PHONE_ATTRIBUTE))!=null)
+                {
+                    toNum = userForm.getFormData().get(pwmApplication.getConfig().getDefaultLdapProfile().readSettingAsString(PwmSetting.SMS_USER_PHONE_ATTRIBUTE));    
+                    if(toNum.isEmpty())
+                    {
+                        toNum=null;
+                    }
+                }
+                
                 final RestTokenDataClient.TokenDestinationData inputTokenDestData = new RestTokenDataClient.TokenDestinationData(
                         null, toNum, null);
                 final RestTokenDataClient restTokenDataClient = new RestTokenDataClient(pwmApplication);
@@ -481,7 +490,11 @@ class NewUserUtils {
                         inputTokenDestData,
                         null,
                         pwmRequest.getLocale());
-
+                if(outputDestTokenData == null || outputDestTokenData.getSms() == null || outputDestTokenData.getSms().isEmpty())
+                {
+                    //avoid sending SMS code token
+                    break;
+                }
                 final String tokenKey;
                 try {
                     final TokenPayload tokenPayload = pwmApplication.getTokenService().createTokenPayload(
@@ -527,7 +540,11 @@ class NewUserUtils {
                         inputTokenDestData,
                         null,
                         pwmRequest.getLocale());
-
+                if(outputDestTokenData == null || outputDestTokenData.getEmail() == null || outputDestTokenData.getEmail().isEmpty())
+                {
+                    //avoid sending Email code token
+                    break;
+                }
                 final String tokenKey;
                 try {
                     final TokenPayload tokenPayload = pwmApplication.getTokenService().createTokenPayload(


### PR DESCRIPTION
If mail/SMS verification are enabled, the updateProfile process and the
newUser process will send a verification token regardless if the value
is empty or not. This would stop a user to complete the registration 
process in case email or mobile number are optional but verification
is enabled. The commit will skip sending the token if email/mobile
values are null or empty (even if the value is sent by the REST 
resolveTokenDestination client)