### PR TITLE
Fixed a style problem in the HTML editor

### DIFF
--- a/server/src/main/webapp/public/resources/html-editor.css
+++ b/server/src/main/webapp/public/resources/html-editor.css
@@ -67,6 +67,7 @@
 
 .html-editor .btn-group button {
     height: 24px;
+    min-width: auto;
     width: 24px;
 }
 


### PR DESCRIPTION
Fixed a problem in the HTML editor where the buttons were being styled too wide when the configuration theme was set to mdefault.

@jrivard please review and merge.