### PR TITLE
Changed page titles from using DIVs to H1s for themes that make use of them

### DIFF
--- a/server/src/main/webapp/WEB-INF/jsp/accountinformation.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/accountinformation.jsp
@@ -41,7 +41,7 @@
         <jsp:param name="pwm.PageName" value="Title_UserInformation"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title" style="display: none;"><pwm:display key="Title_UserInformation" displayIfMissing="true"/></div>
+        <h1 id="page-content-title" style="display: none;"><pwm:display key="Title_UserInformation" displayIfMissing="true"/></h1>
         <div class="tab-container" style="width: 100%; height: 100%;">
             <input name="tabs" type="radio" id="tab-1" checked="checked" class="input"/>
             <label for="tab-1" class="label"><pwm:display key="Title_UserInformation"/></label>

--- a/server/src/main/webapp/WEB-INF/jsp/activateuser-agreement.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/activateuser-agreement.jsp
@@ -36,7 +36,7 @@
         <jsp:param name="pwm.PageName" value="Title_ActivateUser"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ActivateUser" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ActivateUser" displayIfMissing="true"/></h1>
         <%@ include file="fragment/message.jsp" %>
         <% final String expandedText = activateUserBean.getAgreementText(); %>
         <br/><br/>

--- a/server/src/main/webapp/WEB-INF/jsp/activateuser-entercode.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/activateuser-entercode.jsp
@@ -34,7 +34,7 @@
         <jsp:param name="pwm.PageName" value="Title_ActivateUser"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ActivateUser" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ActivateUser" displayIfMissing="true"/></h1>
         <% final ActivateUserBean activateUserBean = JspUtility.getSessionBean(pageContext, ActivateUserBean.class); %>
         <% final String destination = activateUserBean.getTokenDisplayText(); %>
         <p><pwm:display key="Display_RecoverEnterCode" value1="<%=destination%>"/></p>

--- a/server/src/main/webapp/WEB-INF/jsp/activateuser.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/activateuser.jsp
@@ -33,7 +33,7 @@
         <jsp:param name="pwm.PageName" value="Title_ActivateUser"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ActivateUser" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ActivateUser" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_ActivateUser"/></p>
         <form action="<pwm:current-url/>" method="post" name="activateUser" enctype="application/x-www-form-urlencoded" class="pwm-form">
             <%@ include file="fragment/message.jsp" %>

--- a/server/src/main/webapp/WEB-INF/jsp/admin-activity.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/admin-activity.jsp
@@ -54,7 +54,7 @@
         <jsp:param name="pwm.PageName" value="<%=PageName%>"/>
     </jsp:include>
     <div id="centerbody" class="wide">
-        <div id="page-content-title"><pwm:display key="Title_UserActivity" bundle="Admin"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_UserActivity" bundle="Admin"/></h1>
         <%@ include file="fragment/admin-nav.jsp" %>
         <div id="ActivityTabContainer" class="tab-container" style="width: 100%; height: 100%;">
             <input name="tabs" type="radio" id="tab-1" checked="checked" class="input"/>

--- a/server/src/main/webapp/WEB-INF/jsp/admin-analysis.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/admin-analysis.jsp
@@ -61,7 +61,7 @@
         <jsp:param name="pwm.PageName" value="<%=PageName%>"/>
     </jsp:include>
     <div id="centerbody" class="wide">
-        <div id="page-content-title"><pwm:display key="Title_DataAnalysis" bundle="Admin"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_DataAnalysis" bundle="Admin"/></h1>
         <%@ include file="fragment/admin-nav.jsp" %>
         <div class="tab-container" style="width: 100%; height: 100%;" id="analysis-topLevelTab">
             <input name="tabs" type="radio" id="tab-1" checked="checked" class="input"/>

--- a/server/src/main/webapp/WEB-INF/jsp/admin-dashboard.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/admin-dashboard.jsp
@@ -53,7 +53,7 @@
         <jsp:param name="pwm.PageName" value="<%=PageName%>"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_Dashboard" bundle="Admin"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_Dashboard" bundle="Admin"/></h1>
         <%@ include file="fragment/admin-nav.jsp" %>
         <div id="DashboardTabContainer" class="tab-container" style="width: 100%; height: 100%;">
             <input name="tabs" type="radio" id="tab-1" checked="checked" class="input"/>

--- a/server/src/main/webapp/WEB-INF/jsp/admin-logview.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/admin-logview.jsp
@@ -48,7 +48,7 @@
         <jsp:param name="pwm.PageName" value="<%=PageName%>"/>
     </jsp:include>
     <div id="centerbody" style="width: 96%; margin-left: 2%; margin-right: 2%; background: white">
-        <div id="page-content-title"><pwm:display key="Title_LogViewer" bundle="Admin" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_LogViewer" bundle="Admin" displayIfMissing="true"/></h1>
         <%@ include file="fragment/admin-nav.jsp" %>
         <form action="<pwm:current-url/>" method="post" enctype="application/x-www-form-urlencoded"
               name="searchForm" id="searchForm" class="pwm-form">

--- a/server/src/main/webapp/WEB-INF/jsp/admin-tokenlookup.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/admin-tokenlookup.jsp
@@ -49,7 +49,7 @@
         <jsp:param name="pwm.PageName" value="<%=PageName%>"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_TokenLookup" bundle="Admin" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_TokenLookup" bundle="Admin" displayIfMissing="true"/></h1>
         <%@ include file="fragment/admin-nav.jsp" %>
         <% final String tokenKey = tokenlookup_pwmRequest.readParameterAsString("token");%>
         <% if (tokenKey != null && tokenKey.length() > 0) { %>

--- a/server/src/main/webapp/WEB-INF/jsp/admin-urlreference.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/admin-urlreference.jsp
@@ -31,7 +31,7 @@
         <jsp:param name="pwm.PageName" value="Title_URLReference"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_URLReference" bundle="Admin" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_URLReference" bundle="Admin" displayIfMissing="true"/></h1>
         <%@ include file="fragment/admin-nav.jsp" %>
         <br/>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/admin-user-debug.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/admin-user-debug.jsp
@@ -42,7 +42,7 @@
         <jsp:param name="pwm.PageName" value="User Debug"/>
     </jsp:include>
     <div id="centerbody" class="wide">
-        <div id="page-content-title">User Debug</div>
+        <h1 id="page-content-title">User Debug</h1>
         <%@ include file="fragment/admin-nav.jsp" %>
 
         <% final UserDebugDataBean userDebugDataBean = (UserDebugDataBean)JspUtility.getAttribute(pageContext, PwmRequestAttribute.UserDebugData); %>

--- a/server/src/main/webapp/WEB-INF/jsp/changepassword-agreement.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/changepassword-agreement.jsp
@@ -39,7 +39,7 @@
         <jsp:param name="pwm.PageName" value="Title_ChangePassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ChangePassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ChangePassword" displayIfMissing="true"/></h1>
         <% final PasswordStatus passwordStatus = JspUtility.getPwmSession(pageContext).getUserInfo().getPasswordStatus(); %>
         <% if (passwordStatus.isExpired() || passwordStatus.isPreExpired() || passwordStatus.isViolatesPolicy()) { %>
         <h1><pwm:display key="Display_PasswordExpired"/></h1><br/>

--- a/server/src/main/webapp/WEB-INF/jsp/changepassword-complete.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/changepassword-complete.jsp
@@ -35,7 +35,7 @@
         <jsp:param name="pwm.PageName" value="Title_ChangePassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ChangePassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ChangePassword" displayIfMissing="true"/></h1>
         <%@ include file="fragment/message.jsp" %>
         <% final String expandedText = (String) JspUtility.getAttribute(pageContext, PwmRequestAttribute.CompleteText); %>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/changepassword-form.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/changepassword-form.jsp
@@ -38,7 +38,7 @@
         <jsp:param name="pwm.PageName" value="Title_ChangePassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ChangePassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ChangePassword" displayIfMissing="true"/></h1>
         <% if (passwordStatus.isExpired() || passwordStatus.isPreExpired() || passwordStatus.isViolatesPolicy()) { %>
         <h1><pwm:display key="Display_PasswordExpired"/></h1><br/>
         <% } %>

--- a/server/src/main/webapp/WEB-INF/jsp/changepassword-wait.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/changepassword-wait.jsp
@@ -46,7 +46,7 @@
         <jsp:param name="pwm.PageName" value="Title_PleaseWait"/>
     </jsp:include>
     <div id="centerbody" >
-        <div id="page-content-title"><pwm:display key="Title_PleaseWait" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_PleaseWait" displayIfMissing="true"/></h1>
         <%@ include file="/WEB-INF/jsp/fragment/message.jsp" %>
         <p><pwm:display key="Display_PleaseWaitPassword"/></p>
         <div class="meteredProgressBar">

--- a/server/src/main/webapp/WEB-INF/jsp/changepassword-warn.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/changepassword-warn.jsp
@@ -40,7 +40,7 @@
         <jsp:param name="pwm.PageName" value="Title_PasswordWarning"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_PasswordWarning" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_PasswordWarning" displayIfMissing="true"/></h1>
         <p>
             <% if (uiBean.getPasswordExpirationTime() != null) { %>
             <pwm:display key="Display_PasswordWarn"

--- a/server/src/main/webapp/WEB-INF/jsp/changepassword.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/changepassword.jsp
@@ -36,7 +36,7 @@
         <jsp:param name="pwm.PageName" value="Title_ChangePassword"/>
     </jsp:include>
     <div id="centerbody" ng-app="changepassword.module" ng-controller="ChangePasswordController as $ctrl">
-        <div id="page-content-title"><pwm:display key="Title_ChangePassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ChangePassword" displayIfMissing="true"/></h1>
         <pwm:if test="<%=PwmIfTest.passwordExpired%>">
         <h1><pwm:display key="Display_PasswordExpired"/></h1><br/>
         </pwm:if>

--- a/server/src/main/webapp/WEB-INF/jsp/configmanager-certificates.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/configmanager-certificates.jsp
@@ -41,14 +41,14 @@
     </jsp:include>
     <% if ((Boolean)JspUtility.getAttribute(pageContext, PwmRequestAttribute.ConfigHasCertificates)) { %>
     <div id="centerbody">
-        <div id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></div>
+        <h1 id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></h1>
         <%@ include file="fragment/configmanager-nav.jsp" %>
         <div id="certDebugGrid" class="grid">
         </div>
     </div>
     <% } else { %>
     <div id="centerbody">
-        <div id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></div>
+        <h1 id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></h1>
         <%@ include file="fragment/configmanager-nav.jsp" %>
         <p>No certificates are present in the active configuration.</p>
     </div>

--- a/server/src/main/webapp/WEB-INF/jsp/configmanager-localdb.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/configmanager-localdb.jsp
@@ -54,7 +54,7 @@
         <jsp:param name="pwm.PageName" value="<%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%>"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></div>
+        <h1 id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></h1>
         <%@ include file="fragment/configmanager-nav.jsp" %>
         <table style="width:550px" id="table-localDBAbout">
             <tr>

--- a/server/src/main/webapp/WEB-INF/jsp/configmanager-login.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/configmanager-login.jsp
@@ -46,7 +46,7 @@
         <jsp:param name="pwm.PageName" value="<%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%>"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></div>
+        <h1 id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></h1>
         <%@ include file="/WEB-INF/jsp/fragment/message.jsp" %>
         <form action="<pwm:current-url/>" method="post" id="configLogin" name="configLogin" enctype="application/x-www-form-urlencoded"
               class="pwm-form">

--- a/server/src/main/webapp/WEB-INF/jsp/configmanager-permissions.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/configmanager-permissions.jsp
@@ -38,7 +38,7 @@
 <%@ include file="fragment/header.jsp" %>
 <body class="nihilo">
 <div style="padding: 10px">
-    <div id="page-content-title"><pwm:display key="Title_LDAPPermissionRecommendations" bundle="Config" displayIfMissing="true"/></div>
+    <h1 id="page-content-title"><pwm:display key="Title_LDAPPermissionRecommendations" bundle="Config" displayIfMissing="true"/></h1>
     <div>
         <a class="menubutton pwm-basic-link" id="MenuItem_DownloadBundle" title="<pwm:display key="Button_DownloadCSV" bundle="Admin"/>"
            href="manager?processAction=<%=ConfigManagerServlet.ConfigManagerAction.downloadPermissionCsv.toString()%>">

--- a/server/src/main/webapp/WEB-INF/jsp/configmanager-wordlists.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/configmanager-wordlists.jsp
@@ -38,7 +38,7 @@
         <jsp:param name="pwm.PageName" value="<%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%>"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></div>
+        <h1 id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></h1>
         <%@ include file="fragment/configmanager-nav.jsp" %>
         <% { %>
         <table style="width:550px" id="table-wordlistInfo">

--- a/server/src/main/webapp/WEB-INF/jsp/configmanager.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/configmanager.jsp
@@ -45,7 +45,7 @@
         <jsp:param name="pwm.PageName" value="<%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%>"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></div>
+        <h1 id="page-content-title"><%=LocaleHelper.getLocalizedMessage(Config.Title_ConfigManager, JspUtility.getPwmRequest(pageContext))%></h1>
         <%@ include file="fragment/configmanager-nav.jsp" %>
         <table style="width:550px">
             <tr>

--- a/server/src/main/webapp/WEB-INF/jsp/deleteaccount-agreement.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/deleteaccount-agreement.jsp
@@ -36,7 +36,7 @@
         <jsp:param name="pwm.PageName" value="Title_DeleteAccount"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_DeleteAccount" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_DeleteAccount" displayIfMissing="true"/></h1>
         <%@ include file="fragment/message.jsp" %>
         <% final String expandedText = (String)JspUtility.getAttribute(pageContext, PwmRequestAttribute.AgreementText); %>
         <div class="agreementText"><%= expandedText %></div>

--- a/server/src/main/webapp/WEB-INF/jsp/deleteaccount-confirm.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/deleteaccount-confirm.jsp
@@ -36,7 +36,7 @@
         <jsp:param name="pwm.PageName" value="Title_DeleteAccount"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_DeleteAccount" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_DeleteAccount" displayIfMissing="true"/></h1>
         <%@ include file="fragment/message.jsp" %>
         <p><pwm:display key="Display_DeleteUserConfirm"/></p>
         <div class="buttonbar">

--- a/server/src/main/webapp/WEB-INF/jsp/error-http.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/error-http.jsp
@@ -43,7 +43,7 @@
         <jsp:param name="pwm.PageName" value="Title_Error"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_Error" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_Error" displayIfMissing="true"/></h1>
         <br/>
         <h2>HTTP <%=statusCode%></h2>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -43,7 +43,7 @@
         <jsp:param name="pwm.PageName" value="Title_Error"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_Error" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_Error" displayIfMissing="true"/></h1>
         <br/>
         <h2><%=PwmConstants.PWM_APP_NAME%>&nbsp;<%=errorInformation == null ? "" : errorInformation.getError().getErrorCode()%></h2>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-actionchoice.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-actionchoice.jsp
@@ -34,7 +34,7 @@
         <jsp:param name="pwm.PageName" value="Title_ForgottenPassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></h1>
         <%@ include file="/WEB-INF/jsp/fragment/message.jsp" %>
         <p><pwm:display key="Display_RecoverPasswordChoices"/></p>
         <table class="noborder">

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-attributes.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-attributes.jsp
@@ -39,7 +39,7 @@ this is handled this way so on browsers where hiding fields is not possible, the
     <jsp:param name="pwm.PageName" value="Title_RecoverPassword"/>
 </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_RecoverPassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_RecoverPassword" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_RecoverPassword"/></p>
 
         <form name="responseForm" action="<pwm:current-url/>" method="post" enctype="application/x-www-form-urlencoded" class="pwm-form" autocomplete="off">

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-enterotp.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-enterotp.jsp
@@ -33,7 +33,7 @@
         <jsp:param name="pwm.PageName" value="Title_ForgottenPassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></h1>
         <%
             final OTPUserRecord otp = (OTPUserRecord)JspUtility.getAttribute(pageContext, PwmRequestAttribute.ForgottenPasswordOtpRecord);
             final String identifier = otp.getIdentifier();

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-entertoken.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-entertoken.jsp
@@ -36,7 +36,7 @@
         <jsp:param name="pwm.PageName" value="Title_ForgottenPassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></h1>
         <% final ForgottenPasswordBean fpb = JspUtility.getSessionBean(pageContext, ForgottenPasswordBean.class); %>
         <% final String destination = fpb.getProgress().getTokenSentAddress(); %>
         <p><pwm:display key="Display_RecoverEnterCode" value1="<%=destination%>"/></p>

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-method.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-method.jsp
@@ -40,7 +40,7 @@
         <jsp:param name="pwm.PageName" value="Title_ForgottenPassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></h1>
         <%@ include file="/WEB-INF/jsp/fragment/message.jsp" %>
         <p>
             <pwm:display key="Display_RecoverVerificationChoice"/>

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-remote.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-remote.jsp
@@ -35,7 +35,7 @@
         <jsp:param name="pwm.PageName" value="Title_ForgottenPassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></h1>
         <%
             final List<VerificationMethodSystem.UserPrompt> prompts = (List<VerificationMethodSystem.UserPrompt>)JspUtility.getAttribute(pageContext, PwmRequestAttribute.ForgottenPasswordPrompts);
             final String instructions = (String)JspUtility.getAttribute(pageContext, PwmRequestAttribute.ForgottenPasswordInstructions);

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-responses.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-responses.jsp
@@ -41,7 +41,7 @@ this is handled this way so on browsers where hiding fields is not possible, the
     <jsp:param name="pwm.PageName" value="Title_RecoverPassword"/>
 </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_RecoverPassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_RecoverPassword" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_RecoverPassword"/></p>
 
         <form name="responseForm" action="<pwm:current-url/>" method="post" enctype="application/x-www-form-urlencoded" class="pwm-form" autocomplete="off">

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-search.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-search.jsp
@@ -34,7 +34,7 @@
         <jsp:param name="pwm.PageName" value="Title_ForgottenPassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_ForgottenPassword"/></p>
         <form action="<pwm:current-url/>" method="post" enctype="application/x-www-form-urlencoded" autocomplete="off"
               name="searchForm" class="pwm-form" id="searchForm">

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-tokenchoice.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenpassword-tokenchoice.jsp
@@ -35,7 +35,7 @@
         <jsp:param name="pwm.PageName" value="Title_ForgottenPassword"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ForgottenPassword" displayIfMissing="true"/></h1>
         <%@ include file="/WEB-INF/jsp/fragment/message.jsp" %>
         <p><pwm:display key="Display_RecoverTokenSendChoices"/></p>
         <table class="noborder">

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenusername-complete.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenusername-complete.jsp
@@ -35,7 +35,7 @@
         <jsp:param name="pwm.PageName" value="Title_ForgottenUsername"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ForgottenUsername" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ForgottenUsername" displayIfMissing="true"/></h1>
         <%@ include file="fragment/message.jsp" %>
         <% final String expandedText = (String) JspUtility.getAttribute(pageContext, PwmRequestAttribute.CompleteText); %>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/forgottenusername-search.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/forgottenusername-search.jsp
@@ -33,7 +33,7 @@
         <jsp:param name="pwm.PageName" value="Title_ForgottenUsername"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ForgottenUsername" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ForgottenUsername" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_ForgottenUsername"/></p>
         <%@ include file="/WEB-INF/jsp/fragment/message.jsp" %>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/guest-create.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/guest-create.jsp
@@ -37,7 +37,7 @@
         <jsp:param name="pwm.PageName" value="Title_GuestRegistration"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_GuestRegistration" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_GuestRegistration" displayIfMissing="true"/></h1>
         <%@ include file="/WEB-INF/jsp/fragment/guest-nav.jsp" %>
         <p><pwm:display key="Display_GuestRegistration"/></p>
 

--- a/server/src/main/webapp/WEB-INF/jsp/guest-search.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/guest-search.jsp
@@ -31,7 +31,7 @@
         <jsp:param name="pwm.PageName" value="Title_GuestUpdate"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_GuestUpdate" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_GuestUpdate" displayIfMissing="true"/></h1>
         <%@ include file="fragment/guest-nav.jsp"%>
         <p><pwm:display key="Display_GuestUpdate"/></p>
                                                                                       

--- a/server/src/main/webapp/WEB-INF/jsp/guest-update.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/guest-update.jsp
@@ -37,7 +37,7 @@
         <jsp:param name="pwm.PageName" value="Title_GuestUpdate"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_GuestUpdate" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_GuestUpdate" displayIfMissing="true"/></h1>
         <%@ include file="fragment/guest-nav.jsp"%>
         <p><pwm:display key="Display_GuestUpdate"/></p>
         <form action="<pwm:current-url/>" method="post" name="updateGuest" enctype="application/x-www-form-urlencoded" class="pwm-form">

--- a/server/src/main/webapp/WEB-INF/jsp/login-passwordonly.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/login-passwordonly.jsp
@@ -34,7 +34,7 @@
         <jsp:param name="pwm.PageName" value="Title_Login"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_Login" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_Login" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_LoginPasswordOnly"/></p>
         <form action="<pwm:current-url/>" method="post" name="login-password" enctype="application/x-www-form-urlencoded" id="login-password" autocomplete="off" class="pwm-form">
             <%@ include file="/WEB-INF/jsp/fragment/message.jsp" %>

--- a/server/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -34,7 +34,7 @@
         <jsp:param name="pwm.PageName" value="Title_Login"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_Login" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_Login" displayIfMissing="true"/></h1>
         <p>
             <span class="panel-login-display-message"><pwm:display key="Display_Login"/></span>
         </p>

--- a/server/src/main/webapp/WEB-INF/jsp/logout-public.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/logout-public.jsp
@@ -36,7 +36,7 @@
         <jsp:param name="pwm.PageName" value="Title_LogoutPublic"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_LogoutPublic" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_LogoutPublic" displayIfMissing="true"/></h1>
         <%@ include file="fragment/message.jsp" %>
         <p><pwm:display key="Display_LogoutPublic"/></p>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/logout.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/logout.jsp
@@ -36,7 +36,7 @@
         <jsp:param name="pwm.PageName" value="Title_Logout"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_Logout" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_Logout" displayIfMissing="true"/></h1>
         <%@ include file="fragment/message.jsp" %>
         <p><pwm:display key="Display_Logout"/></p>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/newuser-agreement.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/newuser-agreement.jsp
@@ -36,7 +36,7 @@
         <jsp:param name="pwm.PageName" value="Title_NewUser"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_NewUser" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_NewUser" displayIfMissing="true"/></h1>
         <%@ include file="fragment/message.jsp" %>
         <% final String expandedText = (String)JspUtility.getAttribute(pageContext, PwmRequestAttribute.AgreementText); %>
         <br/><br/>

--- a/server/src/main/webapp/WEB-INF/jsp/newuser-entercode.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/newuser-entercode.jsp
@@ -40,7 +40,7 @@
         <jsp:param name="pwm.PageName" value="Title_NewUser"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_NewUser" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_NewUser" displayIfMissing="true"/></h1>
         <% if (newUserBean.getTokenVerificationProgress().getPhase() == TokenVerificationProgress.TokenChannel.EMAIL) { %>
         <p><pwm:display key="Display_RecoverEnterCode" value1="<%=tokenVerificationProgress.getTokenDisplayText()%>"/></p>
         <% } else if (newUserBean.getTokenVerificationProgress().getPhase() == TokenVerificationProgress.TokenChannel.SMS) { %>

--- a/server/src/main/webapp/WEB-INF/jsp/newuser-profilechoice.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/newuser-profilechoice.jsp
@@ -42,7 +42,7 @@
         <jsp:param name="pwm.PageName" value="Title_NewUser"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_NewUser" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_NewUser" displayIfMissing="true"/></h1>
         <%@ include file="/WEB-INF/jsp/fragment/message.jsp" %>
         <p>
             <pwm:display key="Display_NewUserProfile"/>

--- a/server/src/main/webapp/WEB-INF/jsp/newuser-wait.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/newuser-wait.jsp
@@ -50,7 +50,7 @@
         <jsp:param name="pwm.PageName" value="Title_PleaseWait"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_PleaseWait" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_PleaseWait" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_PleaseWaitNewUser"/></p>
         <%@ include file="fragment/message.jsp" %>
         <div class="meteredProgressBar">

--- a/server/src/main/webapp/WEB-INF/jsp/newuser.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/newuser.jsp
@@ -37,7 +37,7 @@
         <jsp:param name="pwm.PageName" value="Title_NewUser"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_NewUser" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_NewUser" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_NewUser"/></p>
         <%@ include file="fragment/message.jsp" %>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/setupotpsecret-existing.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/setupotpsecret-existing.jsp
@@ -31,7 +31,7 @@
         <jsp:param name="pwm.PageName" value="Title_SetupOtpSecret" />
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_SetupOtpSecret" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_SetupOtpSecret" displayIfMissing="true"/></h1>
         <p>
             <pwm:if test="<%=PwmIfTest.hasStoredOtpTimestamp%>">
                 <pwm:display key="Display_WarnExistingOtpSecretTime" value1="@OtpSetupTime@"/>

--- a/server/src/main/webapp/WEB-INF/jsp/setupotpsecret-success.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/setupotpsecret-success.jsp
@@ -41,7 +41,7 @@
         <jsp:param name="pwm.PageName" value="Title_SetupOtpSecret"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_SetupOtpSecret" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_SetupOtpSecret" displayIfMissing="true"/></h1>
         <p><pwm:display key="Success_OtpSetup" bundle="Message"/></p>
         <%@ include file="fragment/message.jsp" %>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/setupotpsecret-test.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/setupotpsecret-test.jsp
@@ -39,7 +39,7 @@
         <jsp:param name="pwm.PageName" value="Title_SetupOtpSecret"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_SetupOtpSecret" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_SetupOtpSecret" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_PleaseVerifyOtp"/></p>
         <%@ include file="fragment/message.jsp" %>
         <form action="<pwm:current-url/>" method="post" name="setupOtpSecret"

--- a/server/src/main/webapp/WEB-INF/jsp/setupotpsecret.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/setupotpsecret.jsp
@@ -55,7 +55,7 @@
         <jsp:param name="pwm.PageName" value="Title_SetupOtpSecret"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_SetupOtpSecret" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_SetupOtpSecret" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_SetupOtpSecret"/></p>
         <%@ include file="fragment/message.jsp" %>
         <div class="tab-container">

--- a/server/src/main/webapp/WEB-INF/jsp/setupresponses-confirm.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/setupresponses-confirm.jsp
@@ -37,7 +37,7 @@
         <jsp:param name="pwm.PageName" value="Title_ConfirmResponses"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ConfirmResponses" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ConfirmResponses" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_ConfirmResponses"/></p>
         <%@ include file="fragment/message.jsp" %>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/setupresponses-existing.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/setupresponses-existing.jsp
@@ -37,7 +37,7 @@
         <jsp:param name="pwm.PageName" value="Title_ConfirmResponses"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_ConfirmResponses" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_ConfirmResponses" displayIfMissing="true"/></h1>
         <p>
             <% if (responseInfoBean != null && responseInfoBean.getTimestamp() != null) { %>
             <pwm:display key="Display_WarnExistingResponseTime" value1="@ResponseSetupTime@"/>

--- a/server/src/main/webapp/WEB-INF/jsp/setupresponses-helpdesk.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/setupresponses-helpdesk.jsp
@@ -37,7 +37,7 @@
         <jsp:param name="pwm.PageName" value="Title_SetupResponses"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_SetupResponses" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_SetupResponses" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_SetupHelpdeskResponses"/></p>
         <form action="<pwm:current-url/>" method="post" name="form-setupResponses"
               enctype="application/x-www-form-urlencoded" id="form-setupResponses" class="pwm-form" autocomplete="off">

--- a/server/src/main/webapp/WEB-INF/jsp/setupresponses.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/setupresponses.jsp
@@ -34,7 +34,7 @@
         <jsp:param name="pwm.PageName" value="Title_SetupResponses"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_SetupResponses" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_SetupResponses" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_SetupResponses"/></p>
         <form action="<pwm:current-url/>" method="post" name="form-setupResponses" enctype="application/x-www-form-urlencoded" id="form-setupResponses" class="pwm-form" autocomplete="off">
             <%@ include file="fragment/message.jsp" %>

--- a/server/src/main/webapp/WEB-INF/jsp/shortcut.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/shortcut.jsp
@@ -46,7 +46,7 @@
         <jsp:param name="pwm.PageName" value="Title_Shortcuts"/>
     </jsp:include>
     <div id="centerbody" class="tile-centerbody">
-        <div id="page-content-title"><pwm:display key="Title_Shortcuts" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_Shortcuts" displayIfMissing="true"/></h1>
         <% if (shortcutItems.isEmpty()) { %>
         <p>No shortcuts</p>
         <% } else { %>

--- a/server/src/main/webapp/WEB-INF/jsp/success.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/success.jsp
@@ -36,7 +36,7 @@
         <jsp:param name="pwm.PageName" value="Title_Success"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_Success" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_Success" displayIfMissing="true"/></h1>
         <form action="<pwm:url url='<%=PwmServletDefinition.PublicCommand.servletUrl()%>' addContext="true"/>" method="post"
               enctype="application/x-www-form-urlencoded" class="pwm-form">
             <p><pwm:SuccessMessage/></p>

--- a/server/src/main/webapp/WEB-INF/jsp/updateprofile-agreement.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/updateprofile-agreement.jsp
@@ -38,7 +38,7 @@
         <jsp:param name="pwm.PageName" value="Title_UpdateProfile"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_UpdateProfile" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_UpdateProfile" displayIfMissing="true"/></h1>
         <%@ include file="fragment/message.jsp" %>
         <% final String expandedText = (String)JspUtility.getAttribute(pageContext, PwmRequestAttribute.AgreementText); %>
         <div class="agreementText"><%= expandedText %></div>

--- a/server/src/main/webapp/WEB-INF/jsp/updateprofile-confirm.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/updateprofile-confirm.jsp
@@ -40,7 +40,7 @@
         <jsp:param name="pwm.PageName" value="Title_UpdateProfileConfirm"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_UpdateProfileConfirm" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_UpdateProfileConfirm" displayIfMissing="true"/></h1>
         <p><pwm:display key="Display_UpdateProfileConfirm"/></p>
         <%@ include file="fragment/message.jsp" %>
         <br/>

--- a/server/src/main/webapp/WEB-INF/jsp/updateprofile-entercode.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/updateprofile-entercode.jsp
@@ -42,7 +42,7 @@
         <jsp:param name="pwm.PageName" value="Title_UpdateProfile"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_UpdateProfile" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_UpdateProfile" displayIfMissing="true"/></h1>
         <% if (updateProfileBean.getTokenVerificationProgress().getPhase() == TokenVerificationProgress.TokenChannel.EMAIL) { %>
         <p><pwm:display key="Display_UpdateProfileEnterCode" value1="<%=tokenVerificationProgress.getTokenDisplayText()%>"/></p>
         <% } else if (updateProfileBean.getTokenVerificationProgress().getPhase() == TokenVerificationProgress.TokenChannel.SMS) { %>

--- a/server/src/main/webapp/WEB-INF/jsp/updateprofile.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/updateprofile.jsp
@@ -32,7 +32,7 @@
         <jsp:param name="pwm.PageName" value="Title_UpdateProfile"/>
     </jsp:include>
     <div id="centerbody">
-        <div id="page-content-title"><pwm:display key="Title_UpdateProfile" displayIfMissing="true"/></div>
+        <h1 id="page-content-title"><pwm:display key="Title_UpdateProfile" displayIfMissing="true"/></h1>
         <jsp:include page="fragment/customlink.jsp"/>
         <br/>
         <p><pwm:display key="Display_UpdateProfile"/></p>

--- a/server/src/main/webapp/config/index.jsp
+++ b/server/src/main/webapp/config/index.jsp
@@ -34,7 +34,7 @@
     </jsp:include>
     <div id="content">
         <div id="centerbody">
-            <div id="page-content-title"><pwm:display key="Title_Configuration" bundle="Config" displayIfMissing="true"/></div>
+            <h1 id="page-content-title"><pwm:display key="Title_Configuration" bundle="Config" displayIfMissing="true"/></h1>
             <pwm:display key="Display_PleaseWait"/> <a href="<pwm:context/><pwm:url url="/private/config/ConfigManage"/>"><pwm:display bundle="Admin" key="MenuItem_ConfigManager"/></a>
         </div>
     </div>

--- a/server/src/main/webapp/private/config/index.jsp
+++ b/server/src/main/webapp/private/config/index.jsp
@@ -38,7 +38,7 @@
     </jsp:include>
     <div id="content">
         <div id="centerbody">
-            <div id="page-content-title"><pwm:display key="Title_Configuration" bundle="Config" displayIfMissing="true"/></div>
+            <h1 id="page-content-title"><pwm:display key="Title_Configuration" bundle="Config" displayIfMissing="true"/></h1>
             <pwm:display key="Display_PleaseWait"/> <a href="<pwm:context/><pwm:url url="/private/config/manager"/>"><pwm:display bundle="Admin" key="MenuItem_ConfigManager"/></a>
         </div>
     </div>


### PR DESCRIPTION
Changed page titles from using DIVs to H1s for themes that make use of them, so they are more compliant with screen reader software (such as JAWS).