### PR TITLE
The web service can edit form fields before they're saved (proposal)

### DIFF
--- a/server/src/main/java/password/pwm/http/servlet/newuser/NewUserServlet.java
+++ b/server/src/main/java/password/pwm/http/servlet/newuser/NewUserServlet.java
@@ -283,6 +283,16 @@ public class NewUserServlet extends ControlledPwmServlet
             }
         }
 
+        // last chance to edit form data before user creation (and DN generation too)
+        try
+        {
+        	NewUserUtils.remoteEditFormData( pwmRequest, newUserBean.getNewUserForm(), null);
+        }
+        catch ( PwmDataValidationException e )
+        {
+            throw new PwmUnrecoverableException( e.getErrorInformation() );
+        }
+        
         // success so create the new user.
         final String newUserDN = NewUserUtils.determineUserDN( pwmRequest, newUserBean.getNewUserForm() );
 

--- a/server/src/main/java/password/pwm/ws/client/rest/form/FormDataRequestBean.java
+++ b/server/src/main/java/password/pwm/ws/client/rest/form/FormDataRequestBean.java
@@ -56,6 +56,7 @@ public class FormDataRequestBean implements Serializable
 
     public enum Mode
     {
+        edit,
         read,
         verify,
         write,


### PR DESCRIPTION
This is a bit invasive with respect to the original code: gives a chance to use the configured web service to edit form fields before they're saved to LDAP. I'm using it to compose a _cn_ from the _sn_ and _givenName_ new user form fields.

It's more of a proposal than a complete pr (in fact there's no logic in case the ws returns an error).