### PR TITLE
Style fixes to fix some display issues...

### DIFF
--- a/server/src/main/webapp/public/resources/style.css
+++ b/server/src/main/webapp/public/resources/style.css
@@ -1693,3 +1693,17 @@ table.ias-table, table.ias-table td {
 .ias-fill {
     display: inline-block;
 }
+
+#analysis-topLevelTab .dgrid-resize-header-container {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+#analysis-topLevelTab .dgrid-scroller {
+    margin-top: 23px !important;
+}
+
+#certDebugGrid .dgrid-hider-toggle {
+    z-index: 900;
+}


### PR DESCRIPTION
Changed the table headers so they stay on one line and don't wrap.  This way, the position of the first line of content is consistent across all the browsers (some browsers were putting the first line of content up into the header area).  This was seen when going to the Administration page, selecting Data Analysis, under the Directory Reporting tab, and Data Viewer sub-tab.

Updated the z-index of the plus icon, so it wasn't overlapping with the dialog content.  This was seen when going to the Configuration Manager, clicking Certificates, and clicking on one of the certificates in the list (the plus sign would show through the dialog content).