### PR TITLE
Fixed Event Statistics (reference) table

### DIFF
--- a/server/src/main/webapp/public/reference/tables.jsp
+++ b/server/src/main/webapp/public/reference/tables.jsp
@@ -71,7 +71,7 @@
                     <%=statistic.getLabel(userLocale)%>
                 </td>
                 <td>
-                    <%=statistic.getKey()%>
+                    <%=statistic.name()%>
                 </td>
                 <td>
                     <%=statistic.getDescription(userLocale)%>


### PR DESCRIPTION
Changed the content of the Event Statistics table to show the name, instead of the key.