### PR TITLE
Hide change password unavailable configuration message

### DIFF
--- a/server/src/main/webapp/WEB-INF/jsp/fragment/form.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/fragment/form.jsp
@@ -45,7 +45,7 @@
 <% final Locale formLocale = formPwmRequest.getLocale(); %>
 <% final List<FormConfiguration> formConfigurationList = (List<FormConfiguration>)JspUtility.getAttribute(pageContext, PwmRequestAttribute.FormConfiguration); %>
 <% if (JavaHelper.isEmpty(formConfigurationList)) { %>
-[ form definition is not available ]
+<!-- [ form definition is not available ] -->
 <% } else { %>
 <%
     final boolean forceReadOnly = (Boolean)JspUtility.getAttribute(pageContext, PwmRequestAttribute.FormReadOnly);


### PR DESCRIPTION
When the (authenticated) change password module is set to require the current password but doesn't ask for any other information a `[ form definition is not available ]` text appears under the "Current Password" field on the page.

This simply turns that text into an HTML comment.