### PR TITLE
Changed the rest/statitics GET 'key data' to return the enum names

### DIFF
--- a/server/src/main/java/password/pwm/ws/server/rest/RestStatisticsServer.java
+++ b/server/src/main/java/password/pwm/ws/server/rest/RestStatisticsServer.java
@@ -137,7 +137,7 @@ public class RestStatisticsServer extends RestServlet
         final Map<String, Object> outputValueMap = new TreeMap<>();
         for ( final Statistic stat : Statistic.values() )
         {
-            outputValueMap.put( stat.getKey(), statisticsBundle.getStatistic( stat ) );
+            outputValueMap.put( stat.name(), statisticsBundle.getStatistic( stat ) );
         }
 
         return outputValueMap;


### PR DESCRIPTION
Changed the rest/statitics GET 'key data' to return the enum names, rather than the 'key' field.  This change is meant to make the documented 'Event Statistics, Key'  values consistant with the names of the values returned by the REST call.