### PR TITLE
Modified REST statistics GET to return stat.name()

### DIFF
--- a/server/src/main/java/password/pwm/ws/server/rest/RestStatisticsServer.java
+++ b/server/src/main/java/password/pwm/ws/server/rest/RestStatisticsServer.java
@@ -137,7 +137,7 @@ public class RestStatisticsServer extends RestServlet
         final Map<String, Object> outputValueMap = new TreeMap<>();
         for ( final Statistic stat : Statistic.values() )
         {
-            outputValueMap.put( stat.getKey(), statisticsBundle.getStatistic( stat ) );
+            outputValueMap.put( stat.name(), statisticsBundle.getStatistic( stat ) );
         }
 
         return outputValueMap;


### PR DESCRIPTION
Modified REST statistics GET to return stat.name() (as documented in the Event Statistics key column) rather than the undocumented stat.getKey values).