### PR TITLE
Added parameter check to REST randompassword POST

### DIFF
--- a/server/src/main/java/password/pwm/error/PwmError.java
+++ b/server/src/main/java/password/pwm/error/PwmError.java
@@ -343,7 +343,11 @@ public enum PwmError
             5300, "Error_HTTP_404", null ),
 
     ERROR_REST_INVOCATION_ERROR(
-            7000, "Error_RestInvocationError", null ),;
+            7000, "Error_RestInvocationError", null ),
+    ERROR_REST_PARAMETER_CONFLICT(
+            7001, "Error_RestParameterConflict", null ),
+
+    /* End of list*/;
 
     enum ErrorFlag
     {

--- a/server/src/main/java/password/pwm/ws/server/rest/RestRandomPasswordServer.java
+++ b/server/src/main/java/password/pwm/ws/server/rest/RestRandomPasswordServer.java
@@ -90,6 +90,17 @@ public class RestRandomPasswordServer extends RestServlet
     public RestResultBean doPostRandomPasswordForm( final RestRequest restRequest )
             throws PwmUnrecoverableException
     {
+        /* Check for parameter conflicts. */
+        if ( restRequest.hasParameter( "username" )
+             && ( restRequest.hasParameter( "strength" ) || restRequest.hasParameter( "minLength" ) || restRequest.hasParameter( "chars" ) ) )
+        {
+            LOGGER.error( restRequest.getSessionLabel(),
+              "REST parameter conflict.  The username parameter cannot be specified if strength, minLength or chars parameters are specified." );
+            final String errorMessage = "REST parameter conflict.  The username parameter cannot be specified if strength, minLength or chars parameters are specified.";
+            final ErrorInformation errorInformation = new ErrorInformation( PwmError.ERROR_REST_PARAMETER_CONFLICT, errorMessage );
+            return RestResultBean.fromError( restRequest, errorInformation );
+        }
+
         final JsonInput jsonInput = new JsonInput();
         jsonInput.username = restRequest.readParameterAsString( "username", PwmHttpRequestWrapper.Flag.BypassValidation );
         jsonInput.strength = restRequest.readParameterAsInt( "strength", 0 );
@@ -122,6 +133,17 @@ public class RestRandomPasswordServer extends RestServlet
     public RestResultBean doPlainRandomPassword( final RestRequest restRequest )
             throws PwmUnrecoverableException
     {
+        /* Check for parameter conflicts. */
+        if ( restRequest.hasParameter( "username" )
+             && ( restRequest.hasParameter( "strength" ) || restRequest.hasParameter( "minLength" ) || restRequest.hasParameter( "chars" ) ) )
+        {
+            LOGGER.error( restRequest.getSessionLabel(),
+              "REST parameter conflict.  The username parameter cannot be specified if strength, minLength or chars parameters are specified." );
+            final String errorMessage = "REST parameter conflict.  The username parameter cannot be specified if strength, minLength or chars parameters are specified.";
+            final ErrorInformation errorInformation = new ErrorInformation( PwmError.ERROR_REST_PARAMETER_CONFLICT, errorMessage );
+            return RestResultBean.fromError( restRequest, errorInformation );
+        }
+
         final JsonInput jsonInput = new JsonInput();
         jsonInput.username = restRequest.readParameterAsString( "username", PwmHttpRequestWrapper.Flag.BypassValidation );
         jsonInput.strength = restRequest.readParameterAsInt( "strength", 0 );


### PR DESCRIPTION
Cause a REST error if 'username' parameter is specified with other parameters.
Added error 7001 to indicate a parameter conflict.