### PR TITLE
Form field default value (for select input only)

### DIFF
--- a/server/src/main/java/password/pwm/config/value/data/FormConfiguration.java
+++ b/server/src/main/java/password/pwm/config/value/data/FormConfiguration.java
@@ -133,6 +133,9 @@ public class FormConfiguration implements Serializable
     private Map<String, String> selectOptions = Collections.emptyMap();
 
     @Builder.Default
+    private String defaultValue = "";
+
+    @Builder.Default
     private List<String> mimeTypes = Arrays.asList(
             "image/gif",
             "image/png",

--- a/server/src/main/resources/password/pwm/i18n/Config.properties
+++ b/server/src/main/resources/password/pwm/i18n/Config.properties
@@ -161,6 +161,7 @@ Tooltip_FormOptions_LinkLabel=Label to be displayed that tells where the link wi
 Tooltip_FormOptions_LinkURL=Full url that you want to go to when the link is selected.
 Tooltip_Form_ShowInNewWindow=Choose if the link will e opened in a new browser window
 Tooltip_FormOptions_Placeholder=Placeholder text to display in the form field with the field is not populated with a value.
+Tooltip_FormOptions_DefaultValue=Field default value.
 Tooltip_FormOptions_Javascript=Javascript to be added to the browser.  This option is depreciated.  Use 'Settings -> User Interface -> Look & Feel -> Embedded JavaScript' instead.
 Tooltip_FormOptions_MultiValue=Display multiple values of the attribute.
 VerificationMethodDetail_PREVIOUS_AUTH=This method is passed when a user has previously authenticated using their browser.  There is no user interaction or display associated with this method.

--- a/server/src/main/webapp/WEB-INF/jsp/fragment/form.jsp
+++ b/server/src/main/webapp/WEB-INF/jsp/fragment/form.jsp
@@ -96,7 +96,16 @@
     <% } else if (loopConfiguration.getType() == FormConfiguration.Type.select) { %>
     <select id="<%=loopConfiguration.getName()%>" name="<%=loopConfiguration.getName()%>" class="inputfield selectfield" <pwm:autofocus/> >
         <% for (final String optionName : loopConfiguration.getSelectOptions().keySet()) {%>
-        <option value="<%=optionName%>" <%if(optionName.equals(currentValue)){%>selected="selected"<%}%>>
+        <option value="<%=optionName%>" <%
+            if (StringUtil.isEmpty(currentValue)) {
+                if (optionName.equals(loopConfiguration.getDefaultValue())) {
+                    out.write("selected=\"selected\"");
+                }
+            } else {
+                if (optionName.equals(currentValue)) {
+                    out.write("selected=\"selected\"");
+                }
+            } %>>
             <%=loopConfiguration.getSelectOptions().get(optionName)%>
         </option>
         <% } %>

--- a/server/src/main/webapp/public/resources/js/configeditor-settings-form.js
+++ b/server/src/main/webapp/public/resources/js/configeditor-settings-form.js
@@ -29,6 +29,7 @@ FormTableHandler.newRowValue = {
     labels:{'':''},
     regexErrors:{'':''},
     selectOptions:{},
+    defaultValue:'',
     description:{'':''},
     type:'text',
     placeholder:'',
@@ -288,6 +289,10 @@ FormTableHandler.showOptionsDialog = function(keyName, iteration) {
         bodyText += '</tr><tr>';
         if (currentValue['type'] === 'select') {
             bodyText += '<td class="key">Select Options</td><td><button class="btn" id="' + inputID + 'editOptionsButton"><span class="btn-icon pwm-icon pwm-icon-list-ul"/> Edit</button></td>';
+            bodyText += '</tr><tr>';
+        }
+        if (currentValue['type'] === 'select') { // temporary condition
+            bodyText += '<td id="' + inputID + '-label-defaultValue" class="key" title="' + PWM_CONFIG.showString('Tooltip_FormOptions_DefaultValue') + '">Default Value</td><td><input type="text" class="configStringInput" style="width:70px" id="' + inputID + 'defaultValue' + '"/></td>';
             bodyText += '</tr>';
         }
     }
@@ -409,6 +414,12 @@ FormTableHandler.showOptionsDialog = function(keyName, iteration) {
             PWM_MAIN.getObject(inputID + "javascript").value = currentValue['javascript'] ? currentValue['javascript'] : '';
             PWM_MAIN.addEventHandler(inputID + "javascript", "change", function(){
                 currentValue['javascript'] = PWM_MAIN.getObject(inputID + "javascript").value;
+                FormTableHandler.write(keyName)
+            });
+
+            PWM_MAIN.getObject(inputID + "defaultValue").value = currentValue['defaultValue'] ? currentValue['defaultValue'] : '';
+            PWM_MAIN.addEventHandler(inputID + "defaultValue", "change", function(){
+                currentValue['defaultValue'] = PWM_MAIN.getObject(inputID + "defaultValue").value;
                 FormTableHandler.write(keyName)
             });
         }


### PR DESCRIPTION
Adds a default value configuration entry for form fields. It is currently only made available for select fields, hence the condition (and the comment) at [configeditor-settings-form.js line 294](#diff-612c009905e953ad83d26fb172229662R294).

There's no input validation and I had tested this only within New User Registration forms.
