### PR TITLE
Review formKey calculation for data validation cache

### DIFF
--- a/server/src/main/webapp/public/resources/js/main.js
+++ b/server/src/main/webapp/public/resources/js/main.js
@@ -1218,8 +1218,8 @@ PWM_MAIN.pwmFormValidator = function(validationProps, reentrant) {
 
     // check if data is in cache, if it is just process it.
     var formData = readDataFunction();
-    var formKey = "";
-    for (var key in formData) {formKey += formData[key] + "-";}
+    var formDataString = JSON.stringify(formData) ;
+    var formKey = formDataString;
 
     {
         var cachedResult = PWM_VAR['validationCache'][formKey];
@@ -1262,8 +1262,6 @@ PWM_MAIN.pwmFormValidator = function(validationProps, reentrant) {
             }
         }, 5);
     }
-
-    var formDataString = JSON.stringify(formData) ;
 
     if (CONSOLE_DEBUG) console.log('FormValidator: sending form data to server... ' + formDataString);
     var loadFunction = function(data) {


### PR DESCRIPTION
In a new user form having two checkboxes (one required and the other optional), I noticed that ticking one checkbox or the other at times bypassed the required field check, letting form submission &mdash; it must be noted that I'm working on a version with has #310 merged in.

This fix adds field names to the validation cache data, avoiding potentially equal field values to trigger misvalidations.