### PR TITLE
fixed issue with trying to unlock non-locked accounts in OpenLDAP

### DIFF
--- a/server/src/main/java/password/pwm/http/servlet/forgottenpw/ForgottenPasswordUtil.java
+++ b/server/src/main/java/password/pwm/http/servlet/forgottenpw/ForgottenPasswordUtil.java
@@ -451,9 +451,16 @@ public class ForgottenPasswordUtil
 
         try
         {
-            // try unlocking user
-            theUser.unlockPassword();
-            LOGGER.trace( pwmRequest, "unlock account succeeded" );
+            if ( theUser.isPasswordLocked() )
+            {
+                // try unlocking user
+                theUser.unlockPassword();
+                LOGGER.trace( pwmRequest, "unlock account succeeded" );
+            }
+            else
+            {
+                LOGGER.debug( pwmRequest, "account is not locked, continuing" );
+            }
         }
         catch ( ChaiOperationException e )
         {


### PR DESCRIPTION
This is a potential fix for my issue #386.
I just tested this with my openLDAP setup, so it schould be checked if this results in issues with other directories
