### PR TITLE
Helpdesk verifications needing tokenData

### DIFF
--- a/client/src/modules/helpdesk/verifications-dialog.controller.ts
+++ b/client/src/modules/helpdesk/verifications-dialog.controller.ts
@@ -53,7 +53,7 @@ export default class VerificationsDialogController {
     inputs: { name: string, label: string }[];
     isDetailsView: boolean;
     status: string;
-    tokenData: IVerificationTokenResponse;
+    tokenData: string;
     viewDetailsEnabled: boolean;
     verificationMethod: string;
     verificationStatus: string;
@@ -163,7 +163,9 @@ export default class VerificationsDialogController {
         let data = {};
         this.objectService.assign(data, this.formData);
         if (this.tokenData) {
-            this.objectService.assign(data, this.tokenData);
+            this.objectService.assign(data, {
+                tokenData: this.tokenData
+            });
         }
         this.helpDeskService.validateVerificationData(this.personUserKey, data, this.verificationMethod)
             .then((response) => {
@@ -190,6 +192,7 @@ export default class VerificationsDialogController {
         this.helpDeskService.sendVerificationToken(this.personUserKey, this.tokenDestinationID)
             .then((response) => {
                 this.verificationTokenSent = true;
+                this.tokenData = (response as any).data.tokenData;
             })
             .catch((reason) => {
                 this.verificationTokenSent = false;

--- a/client/src/services/helpdesk.service.ts
+++ b/client/src/services/helpdesk.service.ts
@@ -51,7 +51,7 @@ export interface IHelpDeskService {
     sendVerificationToken(userKey: string, choice: string): IPromise<IVerificationTokenResponse>;
     setPassword(userKey: string, random: boolean, password?: string): IPromise<ISuccessResponse>;
     unlockIntruder(userKey: string): IPromise<ISuccessResponse>;
-    validateVerificationData(userKey: string, formData: any, tokenData: any): IPromise<IVerificationStatus>;
+    validateVerificationData(userKey: string, formData: any, method: any): IPromise<IVerificationStatus>;
     showStrengthMeter: boolean;
 }
 


### PR DESCRIPTION
Fixed a problem where the helpdesk verifications controller wasn't using the tokenData received in the response after sending the token to the user.