### PR TITLE
Updated a german security question to allow more answers

### DIFF
--- a/server/src/main/resources/password/pwm/config/PwmSetting.xml
+++ b/server/src/main/resources/password/pwm/config/PwmSetting.xml
@@ -2126,7 +2126,7 @@
             <value locale="de"><![CDATA[{"text":"Welches ist Ihre Lieblingsmannschaft?","minLength":4,"maxLength":200,"adminDefined":true,enforceWordlist:true,maxQuestionCharsInAnswer:3}]]></value>
             <value locale="de"><![CDATA[{"text":"In welcher Straße haben Sie als Kind gewohnt?","minLength":4,"maxLength":200,"adminDefined":true,enforceWordlist:true,maxQuestionCharsInAnswer:3}]]></value>
             <value locale="de"><![CDATA[{"text":"Wie lautet Ihr Geburtsort?","minLength":4,"maxLength":200,"adminDefined":true,enforceWordlist:true,maxQuestionCharsInAnswer:3}]]></value>
-            <value locale="de"><![CDATA[{"text":"Welches ist Ihr bevorzugtes Fahrzeug?","minLength":4,"maxLength":200,"adminDefined":true,enforceWordlist:true,maxQuestionCharsInAnswer:3}]]></value>
+            <value locale="de"><![CDATA[{"text":"Welches ist Ihr bevorzugtes Verkehrsmittel?","minLength":4,"maxLength":200,"adminDefined":true,enforceWordlist:true,maxQuestionCharsInAnswer:3}]]></value>
             <value locale="de"><![CDATA[{"text":"Welche historische Persönlichkeit würden Sie gerne kennenlernen?","minLength":4,"maxLength":200,"adminDefined":true,enforceWordlist:true,maxQuestionCharsInAnswer:3}]]></value>
             <value locale="de"><![CDATA[{"text":"Wie heißt der schlechteste Film, den Sie je gesehen haben?","minLength":4,"maxLength":200,"adminDefined":true,enforceWordlist:true,maxQuestionCharsInAnswer:3}]]></value>
             <value locale="de"><![CDATA[{"text":"Wie hieß der Lehrer, den Sie am wenigsten mochten?","minLength":4,"maxLength":200,"adminDefined":true,enforceWordlist:true,maxQuestionCharsInAnswer:3}]]></value>

--- a/server/src/test/resources/password/pwm/util/java/XmlFactoryTest.xml
+++ b/server/src/test/resources/password/pwm/util/java/XmlFactoryTest.xml
@@ -236,7 +236,7 @@
       <value locale="de"><![CDATA[{"text":"Welches ist Ihre Lieblingsmannschaft?","minLength":4,"maxLength":200,"adminDefined":true,"enforceWordlist":true,"maxQuestionCharsInAnswer":3,"points":0}]]></value>
       <value locale="de"><![CDATA[{"text":"In welcher Straße haben Sie als Kind gewohnt?","minLength":4,"maxLength":200,"adminDefined":true,"enforceWordlist":true,"maxQuestionCharsInAnswer":3,"points":0}]]></value>
       <value locale="de"><![CDATA[{"text":"Wie lautet Ihr Geburtsort?","minLength":4,"maxLength":200,"adminDefined":true,"enforceWordlist":true,"maxQuestionCharsInAnswer":3,"points":0}]]></value>
-      <value locale="de"><![CDATA[{"text":"Welches ist Ihr bevorzugtes Fahrzeug?","minLength":4,"maxLength":200,"adminDefined":true,"enforceWordlist":true,"maxQuestionCharsInAnswer":3,"points":0}]]></value>
+      <value locale="de"><![CDATA[{"text":"Welches ist Ihr bevorzugtes Verkehrsmittel?","minLength":4,"maxLength":200,"adminDefined":true,"enforceWordlist":true,"maxQuestionCharsInAnswer":3,"points":0}]]></value>
       <value locale="de"><![CDATA[{"text":"Welche historische Persönlichkeit würden Sie gerne kennenlernen?","minLength":4,"maxLength":200,"adminDefined":true,"enforceWordlist":true,"maxQuestionCharsInAnswer":3,"points":0}]]></value>
       <value locale="de"><![CDATA[{"text":"Wie heißt der schlechteste Film, den Sie je gesehen haben?","minLength":4,"maxLength":200,"adminDefined":true,"enforceWordlist":true,"maxQuestionCharsInAnswer":3,"points":0}]]></value>
       <value locale="de"><![CDATA[{"text":"Wie hieß der Lehrer, den Sie am wenigsten mochten?","minLength":4,"maxLength":200,"adminDefined":true,"enforceWordlist":true,"maxQuestionCharsInAnswer":3,"points":0}]]></value>


### PR DESCRIPTION
When selected german, one cannot answer the question for
favourite "Fahrzeug" (vehicle) with "Fahrrad" (bicycle),
as it's part of the question.

Therefore I changed the term to more generic "Verkehrsmittel",
which allows a greater variety of answers.

https://de.wikipedia.org/wiki/Liste_von_Verkehrs-_und_Transportmitteln

![Screenshot_2019-05-27 Markus Grobelin Password Self Service](https://user-images.githubusercontent.com/310107/58423384-4190c580-8095-11e9-9c88-7e393a6b4c90.png)
