### PR TITLE
Fix issue with smtp and STARTTLS/SMTPS

### DIFF
--- a/server/src/main/java/password/pwm/svc/email/EmailServerUtil.java
+++ b/server/src/main/java/password/pwm/svc/email/EmailServerUtil.java
@@ -168,23 +168,22 @@ public class EmailServerUtil
         try
         {
             final SmtpServerType smtpServerType = profile.readSettingAsEnum( PwmSetting.EMAIL_SERVER_TYPE, SmtpServerType.class );
-            if ( smtpServerType == SmtpServerType.SMTP )
+            if ( smtpServerType == SmtpServerType.START_TLS )
             {
-                return properties;
+                    properties.put( "mail.smtp.starttls.enable", true );
+                    properties.put( "mail.smtp.starttls.required", true );
             }
+            else if ( smtpServerType == SmtpServerType.SMTPS )
+            {
+                    final MailSSLSocketFactory mailSSLSocketFactory = new MailSSLSocketFactory();
+                    mailSSLSocketFactory.setTrustManagers( trustManager );
 
-            final MailSSLSocketFactory mailSSLSocketFactory = new MailSSLSocketFactory();
-            mailSSLSocketFactory.setTrustManagers( trustManager );
-
-            properties.put( "mail.smtp.ssl.enable", true );
-            properties.put( "mail.smtp.ssl.checkserveridentity", true );
-            properties.put( "mail.smtp.socketFactory.fallback", false );
-            properties.put( "mail.smtp.ssl.socketFactory", mailSSLSocketFactory );
-            properties.put( "mail.smtp.ssl.socketFactory.port", port );
-
-            final boolean useStartTls = smtpServerType == SmtpServerType.START_TLS;
-            properties.put( "mail.smtp.starttls.enable", useStartTls );
-            properties.put( "mail.smtp.starttls.required", useStartTls );
+                    properties.put( "mail.smtp.ssl.enable", true );
+                    properties.put( "mail.smtp.ssl.checkserveridentity", true );
+                    properties.put( "mail.smtp.socketFactory.fallback", false );
+                    properties.put( "mail.smtp.ssl.socketFactory", mailSSLSocketFactory );
+                    properties.put( "mail.smtp.ssl.socketFactory.port", port );
+            }
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
We used starttls by setting mail.smtp.starttls.enable=true in advanced settings. After 579c6ab5e it started failing.
I wen't on and checked the new code. I'm not a programmer, but I think that with this piece of code, the advanced settings that are behind this try block will never run when using plain text SMTP.
```
        try
        {
            if ( smtpServerType == SmtpServerType.SMTP )
            {
                return properties;
            }
```

I noticed also that if it was set to use START_TLS, it would also set SSL properties, which is wrong also.
It must be SSL (usually on port 465) or StartTLS (usually port 587). Never both.

As I'm not a programmer, I'm not sure that the small changes that I did are the correct approach for this issue but I tested and it worked for every scenarios that I thought would be more common as:

Plain SMTP with advanced mail.smtp.starttls.enable=true (As I was using before)
Plain SMTP with no starttls (usual no encryption, port 25, with auth).
SMTPS (with auth)
START_TLS (with auth)

Only scenarios that I didn't test are without authentication. But my patch didn't touch that.