### PR TITLE
Added printing of body to External Password Check Post call

### DIFF
--- a/rest-test-service/src/main/java/password/pwm/resttest/ExternalMacroServlet.java
+++ b/rest-test-service/src/main/java/password/pwm/resttest/ExternalMacroServlet.java
@@ -96,6 +96,9 @@ public class ExternalMacroServlet extends HttpServlet
         else if ( req.getServletPath().equals( EXTERNAL_PASSWORD_CHECK_URL ) )
         {
             System.out.println( "External Password Check" );
+            final InputStream inputStream = req.getInputStream();
+            final String body = IOUtils.toString( inputStream );
+            System.out.println( body );
             final boolean error = false;
             final String errorMessage = "No error.";
             resp.setHeader( "Content-Type", "application/json" );


### PR DESCRIPTION
This is just bit easier for debugging so you can put a break point to view the POST body.