### PR TITLE
Need a list of <port> to build

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -55,7 +55,9 @@
                                     <arg>/app/startup.sh</arg>
                                 </entrypoint>
                                 <format>docker</format>
-                                <ports>8443</ports>
+                                <ports>
+                                    <port>8443</port>
+                                </ports>
                                 <volumes>
                                     <volume>/config</volume>
                                 </volumes>


### PR DESCRIPTION
I cloned from latest master, and tried to build the docker image, needs to have a list of `<port>` objects to be able to build the docker image :)