### PR TITLE
Line showing passwords in plain text in the browser: commented.

### DIFF
--- a/webapp/src/main/webapp/public/resources/js/main.js
+++ b/webapp/src/main/webapp/public/resources/js/main.js
@@ -1281,7 +1281,7 @@ PWM_MAIN.pwmFormValidator = function(validationProps, reentrant) {
 
     var formDataString = JSON.stringify(formData) ;
 
-    if (CONSOLE_DEBUG) PWM_MAIN.log('FormValidator: sending form data to server... ' + formDataString);
+    //if (CONSOLE_DEBUG) PWM_MAIN.log('FormValidator: sending form data to server... ' + formDataString);
     var loadFunction = function(data) {
         PWM_VAR['validationInProgress'] = false;
         delete PWM_VAR['validationLastType'];


### PR DESCRIPTION
Hi. I found a line that shows with console.log (I saw it with my browser) the password that I tried to change in a web site. I only commented the line that shows the plain text data. I think it is a problem that could be exploited through social engineering. Greetings!