### PR TITLE
Update onejar-bundled Tomcat to 9.0.39 for v1_9 branch

### DIFF
--- a/onejar/pom.xml
+++ b/onejar/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.root.basedir>${project.basedir}/..</project.root.basedir>
-        <tomcat.version>9.0.22</tomcat.version>
+        <tomcat.version>9.0.39</tomcat.version>
     </properties>
 
     <build>


### PR DESCRIPTION
It looks like the master branch has been getting the Tomcat security updates. Also, it would always be possible to manually build the project with the appropriate override flag (i.e. `-Dtomcat.version=9.0.39`). However, as the v1_9 branch still seems to be considered the current release branch, and since the default value within the onejar POM is being used in the official release artifacts (including the generated Docker container), I figured it would be worth submitting the patch in case anyone else was also considering using the official release artifacts directly.