### PR TITLE
fix incorrectly labeled CAPTCHA v3 as CAPTCHA v2

### DIFF
--- a/server/src/main/java/password/pwm/util/CaptchaUtility.java
+++ b/server/src/main/java/password/pwm/util/CaptchaUtility.java
@@ -70,8 +70,8 @@ public class CaptchaUtility
 
     public enum CaptchaMode
     {
-        V3,
-        V3_INVISIBLE,
+        V2,
+        V2_INVISIBLE,
     }
 
     public static CaptchaMode readCaptchaMode( final PwmRequest pwmRequest )

--- a/server/src/main/resources/password/pwm/config/PwmSetting.xml
+++ b/server/src/main/resources/password/pwm/config/PwmSetting.xml
@@ -1504,11 +1504,11 @@
     </setting>
     <setting hidden="false" key="captcha.recaptcha.mode" level="2">
         <default>
-            <value>V3</value>
+            <value>V2</value>
         </default>
         <options>
-            <option value="V3">reCaptcha Version 3</option>
-            <option value="V3_INVISIBLE">reCaptcha Version 3 - Invisible</option>
+            <option value="V2">reCaptcha Version 2</option>
+            <option value="V2_INVISIBLE">reCaptcha Version 2 - Invisible</option>
         </options>
     </setting>
     <setting hidden="false" key="security.formNonce.enable" level="2" required="true">

--- a/server/src/test/resources/password/pwm/config/stored/ConfigurationCleanerTest.xml
+++ b/server/src/test/resources/password/pwm/config/stored/ConfigurationCleanerTest.xml
@@ -1331,7 +1331,7 @@
         </setting>
         <setting key="captcha.recaptcha.mode" syntax="SELECT" syntaxVersion="0" modifyTime="2018-11-09T09:07:51Z" modifyUser="ldap1|cn=testuser,ou=example,o=org">
             <label>reCAPTCHA Mode</label>
-            <value><![CDATA[V3_INVISIBLE]]></value>
+            <value><![CDATA[V2_INVISIBLE]]></value>
         </setting>
         <setting key="security.cspHeader" syntax="STRING" syntaxVersion="0" modifyTime="2018-11-28T22:49:47Z" modifyUser="ldap1|cn=testuser,ou=example,o=org">
             <label>HTTP Content Security Policy Header</label>

--- a/server/src/test/resources/password/pwm/util/java/XmlFactoryTest.xml
+++ b/server/src/test/resources/password/pwm/util/java/XmlFactoryTest.xml
@@ -1335,7 +1335,7 @@
     </setting>
     <setting key="captcha.recaptcha.mode" syntax="SELECT" syntaxVersion="0" modifyTime="2018-11-09T09:07:51Z" modifyUser="ldap1|cn=testuser,ou=example,o=org">
       <label>reCAPTCHA Mode</label>
-      <value><![CDATA[V3_INVISIBLE]]></value>
+      <value><![CDATA[V2_INVISIBLE]]></value>
     </setting>
     <setting key="security.cspHeader" syntax="STRING" syntaxVersion="0" modifyTime="2018-11-28T22:49:47Z" modifyUser="ldap1|cn=testuser,ou=example,o=org">
       <label>HTTP Content Security Policy Header</label>

--- a/webapp/src/main/webapp/WEB-INF/jsp/fragment/captcha-embed.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/fragment/captcha-embed.jsp
@@ -38,7 +38,7 @@
     <span><pwm:display key="Display_JavascriptRequired"/></span>
     <a href="<pwm:context/>"><pwm:display key="Title_MainPage"/></a>
 </noscript>
-<% if ( captchaMode == CaptchaUtility.CaptchaMode.V3 ) { %>
+<% if ( captchaMode == CaptchaUtility.CaptchaMode.V2 ) { %>
 <%-- begin reCaptcha section (http://code.google.com/apis/recaptcha/docs/display.html) --%>
 <pwm:script>
     <script type="text/javascript">
@@ -60,8 +60,8 @@
 </pwm:script>
 <script nonce="<pwm:value name="<%=PwmValue.cspNonce%>"/>" src="<%=(String)JspUtility.getAttribute(pageContext,PwmRequestAttribute.CaptchaClientUrl)%>?onload=onloadCallback&render=explicit" defer async></script>
 <% } %>
-<% if ( captchaMode == CaptchaUtility.CaptchaMode.V3_INVISIBLE ) { %>
-<!-- captcha v3-invisible 1.0 -->
+<% if ( captchaMode == CaptchaUtility.CaptchaMode.V2_INVISIBLE ) { %>
+<!-- captcha v2-invisible 1.0 -->
 <input type="hidden" name="<%=CaptchaUtility.PARAM_RECAPTCHA_FORM_NAME%>" id="<%=CaptchaUtility.PARAM_RECAPTCHA_FORM_NAME%>"/>
 <pwm:script>
     <script type="text/javascript">

--- a/webapp/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -171,7 +171,7 @@
     <%@ include file="/WEB-INF/jsp/fragment/cancel-form.jsp" %>
 </pwm:if>
 <% if (CaptchaUtility.captchaEnabledForRequest(JspUtility.getPwmRequest(pageContext))) { %>
-<% if (CaptchaUtility.readCaptchaMode( JspUtility.getPwmRequest( pageContext ) ) == CaptchaUtility.CaptchaMode.V3 ) { %>
+<% if (CaptchaUtility.readCaptchaMode( JspUtility.getPwmRequest( pageContext ) ) == CaptchaUtility.CaptchaMode.V2 ) { %>
 <pwm:script>
     <script type="text/javascript">
         PWM_GLOBAL['startupFunctions'].push(function(){


### PR DESCRIPTION
Based on the [pwm-general discussion](https://groups.google.com/g/pwm-general/c/Sp9i8LJSthk),  where it was determined that PWM is using reCaptcha v2, not v3.

Making this change is not backwards-compatible with existing PwmConfiguration.xml config files that have configured "captcha.recaptcha.mode" with "V3" or "V3_INVISIBLE", since the config option changes to "V2" or "V2_INVISIBLE".  Existing users would have to update their config file to continue using reCaptcha.