### PR TITLE
Enabled chai provider with proxy user if SSO enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@
 */*.project
 
 
+.vscode/*

--- a/server/src/main/java/password/pwm/http/servlet/PwmServletDefinition.java
+++ b/server/src/main/java/password/pwm/http/servlet/PwmServletDefinition.java
@@ -76,9 +76,9 @@ public enum PwmServletDefinition
     Resource( password.pwm.http.servlet.resource.ResourceFileServlet.class, null ),
 
     AccountInformation( AccountInformationServlet.class, null ),
-    PrivateChangePassword( PrivateChangePasswordServlet.class, ChangePasswordBean.class, Flag.RequiresUserPasswordAndBind ),
+    PrivateChangePassword( PrivateChangePasswordServlet.class, ChangePasswordBean.class ),
     SetupResponses( password.pwm.http.servlet.SetupResponsesServlet.class, SetupResponsesBean.class, Flag.RequiresUserPasswordAndBind ),
-    UpdateProfile( UpdateProfileServlet.class, UpdateProfileBean.class, Flag.RequiresUserPasswordAndBind ),
+    UpdateProfile( UpdateProfileServlet.class, UpdateProfileBean.class ),
     SetupOtp( password.pwm.http.servlet.SetupOtpServlet.class, SetupOtpBean.class, Flag.RequiresUserPasswordAndBind ),
     Helpdesk( password.pwm.http.servlet.helpdesk.HelpdeskServlet.class, null ),
     Shortcuts( password.pwm.http.servlet.ShortcutServlet.class, ShortcutsBean.class ),

--- a/server/src/main/java/password/pwm/http/servlet/changepw/ChangePasswordServlet.java
+++ b/server/src/main/java/password/pwm/http/servlet/changepw/ChangePasswordServlet.java
@@ -557,11 +557,6 @@ public abstract class ChangePasswordServlet extends ControlledPwmServlet
 
         getProfile( pwmRequest );
 
-        if ( pwmSession.getLoginInfoBean().getType() == AuthenticationType.AUTH_WITHOUT_PASSWORD )
-        {
-            throw new PwmUnrecoverableException( PwmError.ERROR_PASSWORD_REQUIRED );
-        }
-
         if ( !pwmRequest.isAuthenticated() )
         {
             pwmRequest.respondWithError( PwmError.ERROR_AUTHENTICATION_REQUIRED.toInfo() );

--- a/server/src/main/java/password/pwm/ldap/auth/LDAPAuthenticationRequest.java
+++ b/server/src/main/java/password/pwm/ldap/auth/LDAPAuthenticationRequest.java
@@ -199,8 +199,21 @@ class LDAPAuthenticationRequest implements AuthenticationRequest
 
         preAuthenticationChecks();
 
+        final boolean alwaysUseProxyIsEnabled = pwmDomain.getConfig().readSettingAsBoolean( PwmSetting.AD_USE_PROXY_FOR_FORGOTTEN );
+        ChaiProvider returnProvider;
+        
+        try 
+        {
+            returnProvider = alwaysUseProxyIsEnabled ? makeProxyProvider() : null;
+        }
+        catch ( final ChaiUnavailableException ex )
+        {   
+            log( PwmLogLevel.WARN, () -> "Unable to obtain chai provider for proxy user" );
+            returnProvider = null;
+        }
+        
         final AuthenticationResult authenticationResult = new AuthenticationResult(
-                null,
+                returnProvider,
                 AuthenticationType.AUTH_WITHOUT_PASSWORD,
                 null
         );


### PR DESCRIPTION
Some modules like the Change Password or Update profile modules do not support SSO authentication. This because
1. The servlets specify the flag Flag.RequiresUserPasswordAndBind
2. If the user logs on the service using an SSO method, pwm does not know the current password of him/her, thus is not able to create a Chai Provider using the user credentials

In case a proxy user has been defined, this one can be used to generate the chai provider for SSO users. The pull request check if the proxy user is defined and, if so, create a chai provider based on the proxy user in the authenticateUserWithoutPassword method.

Resolve #619