### PR TITLE
fix LDAP search filter for admin permissions

### DIFF
--- a/server/src/main/java/password/pwm/util/PropertyConfigurationImporter.java
+++ b/server/src/main/java/password/pwm/util/PropertyConfigurationImporter.java
@@ -265,7 +265,7 @@ public class PropertyConfigurationImporter
         interestedProperties.add( PropertyKey.UA_ADMIN );
         interestedProperties.add( PropertyKey.RPT_ADMIN );
 
-        final String filter = "( objectclass=* )";
+        final String filter = "(objectclass=*)";
         final List<UserPermission> permissions = new ArrayList<>( );
 
         for ( final PropertyKey propertyKey : interestedProperties )


### PR DESCRIPTION
Space padding is not allowed in LDAP search filter strings. The current filter causes `javax.naming.directory.InvalidSearchFilterException: invalid attribute description` errors.