### PR TITLE
Support fixed and latest JDK version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,13 +6,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: [11, 11.0.3]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'zulu'
     - name: Build with Maven
       run: mvn -B verify --file pom.xml


### PR DESCRIPTION
When you do your CI/CD pipeline against both the random latest JDK 11, as well as a fixed version, you'll more easily be able to identify problems related to the random latest JDK 11 version; Zulu provides a complete archived history of all JDK versions and so is a good distro to use for this.