### PR TITLE
Implement Logout After Profile Update option

### DIFF
--- a/server/src/main/java/password/pwm/bean/LocalSessionStateBean.java
+++ b/server/src/main/java/password/pwm/bean/LocalSessionStateBean.java
@@ -63,6 +63,7 @@ public class LocalSessionStateBean implements Serializable
     private Instant sessionLastAccessedTime;
 
     private boolean passwordModified;
+    private boolean profileModified;
     private boolean privateUrlAccessed;
     private boolean captchaBypassedViaParameter;
 

--- a/server/src/main/java/password/pwm/config/PwmSetting.java
+++ b/server/src/main/java/password/pwm/config/PwmSetting.java
@@ -951,6 +951,8 @@ public enum PwmSetting
             "updateAttributes.email.verification", PwmSettingSyntax.BOOLEAN, PwmSettingCategory.UPDATE_PROFILE ),
     UPDATE_PROFILE_SMS_VERIFICATION(
             "updateAttributes.sms.verification", PwmSettingSyntax.BOOLEAN, PwmSettingCategory.UPDATE_PROFILE ),
+    UPDATE_PROFILE_LOGOUT_AFTER_UPDATE(
+            "updateAttributes.logoutAfterUpdate", PwmSettingSyntax.BOOLEAN, PwmSettingCategory.UPDATE_PROFILE ),
     UPDATE_PROFILE_TOKEN_LIFETIME_EMAIL(
             "updateAttributes.token.lifetime", PwmSettingSyntax.DURATION, PwmSettingCategory.UPDATE_PROFILE ),
     UPDATE_PROFILE_TOKEN_LIFETIME_SMS(

--- a/server/src/main/java/password/pwm/http/servlet/command/CommandServlet.java
+++ b/server/src/main/java/password/pwm/http/servlet/command/CommandServlet.java
@@ -153,6 +153,14 @@ public abstract class CommandServlet extends ControlledPwmServlet
                 pwmRequest.sendRedirect( PwmServletDefinition.Logout );
                 return ProcessStatus.Halt;
             }
+
+            final boolean forceLogoutOnUpdate = pwmSession.getSessionManager().getUpdateAttributeProfile().readSettingAsBoolean( PwmSetting.UPDATE_PROFILE_LOGOUT_AFTER_UPDATE );
+            if ( forceLogoutOnUpdate && pwmSession.getSessionStateBean().isProfileModified() )
+            {
+                LOGGER.trace( pwmRequest, () -> "logging out user; profile has been modified" );
+                pwmRequest.sendRedirect( PwmServletDefinition.Logout );
+                return ProcessStatus.Halt;
+            }
         }
 
         redirectToForwardURL( pwmRequest );

--- a/server/src/main/java/password/pwm/http/servlet/updateprofile/UpdateProfileServlet.java
+++ b/server/src/main/java/password/pwm/http/servlet/updateprofile/UpdateProfileServlet.java
@@ -426,6 +426,9 @@ public class UpdateProfileServlet extends ControlledPwmServlet
             // mark the event log
             pwmApplication.getAuditManager().submit( AuditEvent.UPDATE_PROFILE, pwmSession.getUserInfo(), pwmSession );
 
+            // update the session state bean's profile modified flag
+            pwmSession.getSessionStateBean().setProfileModified( true );
+
             // clear the bean
             pwmApplication.getSessionStateService().clearBean( pwmRequest, UpdateProfileBean.class );
 

--- a/server/src/main/resources/password/pwm/i18n/PwmSetting.properties
+++ b/server/src/main/resources/password/pwm/i18n/PwmSetting.properties
@@ -755,6 +755,7 @@ Setting_Description_updateAttributes.sms.verification=Enable this option to send
 Setting_Description_updateAttributes.token.lifetime=Specify the lifetime a update profile email token is valid (in seconds). The default is 0.   When set to 0, the effective value is inherited from the setting <code>@PwmSettingReference\:token.lifetime@</code>
 Setting_Description_updateAttributes.token.lifetime.sms=Specify the lifetime a new user update profile SMS token is valid (in seconds). The default is 0.  When set to 0, the effective value is inherited from the setting <code>@PwmSettingReference\:token.lifetime@</code>
 Setting_Description_updateAttributes.customLinks=Create custom links for users to navigate to while updating their profile data.
+Setting_Description_updateAttributes.logoutAfterUpdate=Logout the user after they have successfully updated their profile.
 Setting_Description_updateAttributes.writeAttributes=Add actions to execute after @PwmAppName@ populates a user's attributes.
 Setting_Description_urlshortener.classname=Specify the URL Shortening Service class name. The Java full class name that implements a short URL service. You must include the corresponding JAR or ZIP file in the classpath, typically in the <i>WEB-INF/lib</i> directory or the application server's lib directory.
 Setting_Description_urlshortener.parameters=Specify the Name/Value settings used to configure the selected URL shortening service. For example, an API key, user name, password or domain name. The settings must be in "name\=value" format, where name is the key value of a valid service setting.
@@ -1284,6 +1285,7 @@ Setting_Label_updateAttributes.forceSetup=Force Update Profile
 Setting_Label_updateAttributes.form=Update Profile Form
 Setting_Label_updateAttributes.profile.list=Update Attributes Profiles
 Setting_Label_updateAttributes.queryMatch=Update Profile Match
+Setting_Label_updateAttributes.logoutAfterUpdate=Logout After Update
 Setting_Label_updateAttributes.showConfirmation=Show Update Profile Confirmation
 Setting_Label_updateAttributes.sms.verification=Enable SMS Verification
 Setting_Label_updateAttributes.token.lifetime=Update Profile Email Token Maximum Lifetime


### PR DESCRIPTION

Added a new configuration setting 'Logout After Update' to the Update Profile module. This mirrors the existing behavior of 'Logout After Password Change'.
