### PR TITLE
PWM-735: Use PKIX path validation for CA_ONLY certificate trust

### DIFF
--- a/server/src/main/java/password/pwm/util/secure/PwmTrustManager.java
+++ b/server/src/main/java/password/pwm/util/secure/PwmTrustManager.java
@@ -23,16 +23,15 @@ package password.pwm.util.secure;
 import password.pwm.AppProperty;
 import password.pwm.PwmConstants;
 import password.pwm.config.Configuration;
-import password.pwm.error.PwmError;
-import password.pwm.error.PwmUnrecoverableException;
 import password.pwm.util.java.JavaHelper;
 import password.pwm.util.logging.PwmLogger;
 
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.SignatureException;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -94,70 +93,99 @@ public class PwmTrustManager implements X509TrustManager
     )
             throws CertificateException
     {
-        final Optional<List<X509Certificate>> rootCa = X509Utils.extractRootCaCertificates( trustedCertificates );
-
         if ( JavaHelper.isEmpty( trustedCertificates ) )
         {
             final String errorMsg = "no ROOT certificates in configuration trust store for this operation";
             throw new CertificateException( errorMsg );
         }
 
+        final Optional<List<X509Certificate>> rootCa = X509Utils.extractRootCaCertificates( trustedCertificates );
+
         if ( rootCa.isPresent() )
         {
-            for ( final X509Certificate presentedCert : presentedCertificates )
-            {
-                try
-                {
-                    doRootCaValidation( rootCa.get(), presentedCert );
-                }
-                catch ( final PwmUnrecoverableException e )
-                {
-                    throw new CertificateException( e.getMessage() );
-                }
-            }
+            validateUsingCaCertificates( rootCa.get(), presentedCertificates );
             return;
         }
 
         doSelfSignedValidation( trustedCertificates, presentedCertificates );
     }
 
-    private static void doRootCaValidation(
-            final List<X509Certificate> rootCertificates,
-            final X509Certificate testCertificate
+    /**
+     * Validate the presented certificate chain against the configured CA certificate(s) using a standard
+     * PKIX certification-path validator (RFC 5280).  The configured CA certificate(s) are used as trust
+     * anchors and the intermediate certificate(s) supplied by the remote server are used to build the path.
+     *
+     * <p>This replaces an earlier flat, per-certificate signature check which required every certificate
+     * presented by the server to be <em>directly</em> signed by a configured certificate.  That earlier
+     * behavior meant that, for a typical {@code leaf -> intermediate -> root} chain, configuring only the
+     * root CA was insufficient (the leaf is signed by the intermediate, not the root) and every intermediate
+     * had to be configured explicitly.  Proper path building lets a configured root CA validate the full
+     * chain using the server-supplied intermediate(s).  See pwm-project/pwm issue 735.</p>
+     */
+    private void validateUsingCaCertificates(
+            final List<X509Certificate> caCertificates,
+            final List<X509Certificate> presentedCertificates
     )
-            throws PwmUnrecoverableException
+            throws CertificateException
     {
-        boolean passed = false;
-        final StringBuilder errorText = new StringBuilder(  );
-        for ( final X509Certificate rootCA : rootCertificates )
+        if ( JavaHelper.isEmpty( presentedCertificates ) )
         {
-            if ( !passed )
+            throw new CertificateException( "no certificates were presented by the remote server" );
+        }
+
+        final X509TrustManager delegateTrustManager;
+        try
+        {
+            final KeyStore keyStore = KeyStore.getInstance( KeyStore.getDefaultType() );
+            keyStore.load( null, null );
+
+            int index = 0;
+            for ( final X509Certificate caCertificate : caCertificates )
             {
-                try
+                keyStore.setCertificateEntry( "ca-" + index, caCertificate );
+                index++;
+            }
+
+            // explicitly request PKIX (rather than getDefaultAlgorithm(), which can be overridden to the
+            // legacy SunX509 via the ssl.TrustManagerFactory.algorithm security property) so that proper
+            // RFC 5280 certification-path building is always used.
+            final TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance( "PKIX" );
+            trustManagerFactory.init( keyStore );
+
+            delegateTrustManager = firstX509TrustManager( trustManagerFactory.getTrustManagers() );
+        }
+        catch ( final GeneralSecurityException | IOException e )
+        {
+            throw new CertificateException( "unable to initialize PKIX trust manager for configured CA certificate(s): " + e.getMessage() );
+        }
+
+        try
+        {
+            final X509Certificate[] chain = presentedCertificates.toArray( new X509Certificate[0] );
+            final String authType = chain[0].getPublicKey().getAlgorithm();
+            delegateTrustManager.checkServerTrusted( chain, authType );
+        }
+        catch ( final CertificateException e )
+        {
+            final String errorMsg = "server certificate chain is not trusted by configured ROOT CA certificate(s): " + e.getMessage();
+            LOGGER.trace( () -> errorMsg );
+            throw new CertificateException( errorMsg );
+        }
+    }
+
+    private static X509TrustManager firstX509TrustManager( final TrustManager[] trustManagers ) throws CertificateException
+    {
+        if ( trustManagers != null )
+        {
+            for ( final TrustManager trustManager : trustManagers )
+            {
+                if ( trustManager instanceof X509TrustManager )
                 {
-                    // first check certificate equality.  if certificate is same, we don't need to verify it signed itself
-                    if ( !testCertificate.equals( rootCA ) )
-                    {
-                        testCertificate.verify( rootCA.getPublicKey() );
-                    }
-                    passed = true;
-                }
-                catch ( final NoSuchAlgorithmException | SignatureException | NoSuchProviderException | InvalidKeyException | CertificateException e )
-                {
-                    final String msg = "server certificate " + X509Utils.makeDebugText( testCertificate )
-                            + " is not trusted by ROOT CA " + X509Utils.makeDebugText( rootCA );
-                    LOGGER.trace( () -> msg );
-                    errorText.append( msg ).append( "  " );
+                    return ( X509TrustManager ) trustManager;
                 }
             }
         }
-
-        if ( !passed )
-        {
-            final String errorMsg = "server certificate " + X509Utils.makeDebugText( testCertificate )
-                    + " is not signed by configured ROOT CA certificate(s): " + errorText.toString();
-            throw PwmUnrecoverableException.newException( PwmError.ERROR_CERTIFICATE_ERROR, errorMsg );
-        }
+        throw new CertificateException( "no X509TrustManager available for configured CA certificate(s)" );
     }
 
     private void doSelfSignedValidation(

--- a/server/src/test/java/password/pwm/util/secure/PwmTrustManagerTest.java
+++ b/server/src/test/java/password/pwm/util/secure/PwmTrustManagerTest.java
@@ -1,0 +1,180 @@
+/*
+ * Password Management Servlets (PWM)
+ * http://www.pwm-project.org
+ *
+ * Copyright (c) 2006-2009 Novell, Inc.
+ * Copyright (c) 2009-2023 The PWM Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package password.pwm.util.secure;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import password.pwm.config.option.CertificateMatchingMode;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Tests for pwm-project/pwm issue 735: in {@code CA_ONLY} mode, configuring only a root CA should
+ * validate a {@code leaf -> intermediate -> root} chain using the intermediate(s) supplied by the
+ * remote server, rather than requiring every intermediate to be configured explicitly.
+ */
+public class PwmTrustManagerTest
+{
+    private static X509Certificate rootCert;
+    private static X509Certificate intermediateCert;
+    private static X509Certificate leafCert;
+    private static X509Certificate unrelatedRootCert;
+
+    private static final TrustManagerSettings CA_ONLY_SETTINGS =
+            new TrustManagerSettings( false, false, CertificateMatchingMode.CA_ONLY );
+
+    @BeforeClass
+    public static void generateChain() throws Exception
+    {
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( "RSA" );
+        keyPairGenerator.initialize( 2048 );
+
+        final KeyPair rootKeyPair = keyPairGenerator.generateKeyPair();
+        final KeyPair intermediateKeyPair = keyPairGenerator.generateKeyPair();
+        final KeyPair leafKeyPair = keyPairGenerator.generateKeyPair();
+        final KeyPair unrelatedRootKeyPair = keyPairGenerator.generateKeyPair();
+
+        final X500Name rootDn = new X500Name( "CN=PWM Test Root CA" );
+        final X500Name intermediateDn = new X500Name( "CN=PWM Test Intermediate CA" );
+        final X500Name leafDn = new X500Name( "CN=server.example.edu" );
+        final X500Name unrelatedRootDn = new X500Name( "CN=PWM Test Unrelated Root CA" );
+
+        // root: self-signed CA
+        rootCert = makeCertificate( rootDn, rootKeyPair.getPublic(), rootDn, rootKeyPair.getPrivate(), true, BigInteger.valueOf( 1 ) );
+        // intermediate: CA, signed by root
+        intermediateCert = makeCertificate( intermediateDn, intermediateKeyPair.getPublic(), rootDn, rootKeyPair.getPrivate(), true, BigInteger.valueOf( 2 ) );
+        // leaf: end-entity, signed by intermediate
+        leafCert = makeCertificate( leafDn, leafKeyPair.getPublic(), intermediateDn, intermediateKeyPair.getPrivate(), false, BigInteger.valueOf( 3 ) );
+        // an unrelated, independently-rooted CA used to prove untrusted chains are rejected
+        unrelatedRootCert = makeCertificate( unrelatedRootDn, unrelatedRootKeyPair.getPublic(), unrelatedRootDn, unrelatedRootKeyPair.getPrivate(), true, BigInteger.valueOf( 1 ) );
+    }
+
+    private static X509Certificate makeCertificate(
+            final X500Name subjectDn,
+            final PublicKey subjectPublicKey,
+            final X500Name issuerDn,
+            final PrivateKey issuerPrivateKey,
+            final boolean isCa,
+            final BigInteger serial
+    )
+            throws Exception
+    {
+        final Date notBefore = Date.from( Instant.now().minus( 1, ChronoUnit.DAYS ) );
+        final Date notAfter = Date.from( Instant.now().plus( 365, ChronoUnit.DAYS ) );
+
+        final JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                issuerDn, serial, notBefore, notAfter, subjectDn, subjectPublicKey );
+
+        builder.addExtension( Extension.basicConstraints, true, new BasicConstraints( isCa ) );
+        if ( isCa )
+        {
+            // keyCertSign is what X509Utils.certIsRootCA() keys on, and what PKIX requires of CA certs
+            builder.addExtension( Extension.keyUsage, true, new KeyUsage( KeyUsage.keyCertSign | KeyUsage.cRLSign ) );
+        }
+
+        final ContentSigner signer = new JcaContentSignerBuilder( "SHA256withRSA" ).build( issuerPrivateKey );
+        final X509CertificateHolder holder = builder.build( signer );
+        return new JcaX509CertificateConverter().getCertificate( holder );
+    }
+
+    private static PwmTrustManager caOnlyTrustManager( final List<X509Certificate> configuredCerts )
+    {
+        return PwmTrustManager.createPwmTrustManager( CA_ONLY_SETTINGS, configuredCerts );
+    }
+
+    @Test
+    public void configuringOnlyRootValidatesChainWithServerSuppliedIntermediate() throws Exception
+    {
+        final PwmTrustManager trustManager = caOnlyTrustManager( Collections.singletonList( rootCert ) );
+
+        // server presents leaf + intermediate (typical); only the root is configured
+        trustManager.checkServerTrusted( new X509Certificate[] { leafCert, intermediateCert }, "RSA" );
+    }
+
+    @Test
+    public void configuringRootAndIntermediateStillValidates() throws Exception
+    {
+        final PwmTrustManager trustManager = caOnlyTrustManager( java.util.Arrays.asList( rootCert, intermediateCert ) );
+
+        trustManager.checkServerTrusted( new X509Certificate[] { leafCert, intermediateCert }, "RSA" );
+    }
+
+    @Test
+    public void serverSendingFullChainIncludingRootValidates() throws Exception
+    {
+        final PwmTrustManager trustManager = caOnlyTrustManager( Collections.singletonList( rootCert ) );
+
+        trustManager.checkServerTrusted( new X509Certificate[] { leafCert, intermediateCert, rootCert }, "RSA" );
+    }
+
+    @Test
+    public void chainNotTrustedByConfiguredRootIsRejected()
+    {
+        final PwmTrustManager trustManager = caOnlyTrustManager( Collections.singletonList( unrelatedRootCert ) );
+
+        try
+        {
+            trustManager.checkServerTrusted( new X509Certificate[] { leafCert, intermediateCert }, "RSA" );
+            Assert.fail( "expected CertificateException for a chain not anchored to the configured CA" );
+        }
+        catch ( final CertificateException e )
+        {
+            // expected
+        }
+    }
+
+    @Test
+    public void emptyConfiguredTrustStoreIsRejected()
+    {
+        final PwmTrustManager trustManager = caOnlyTrustManager( Collections.emptyList() );
+
+        try
+        {
+            trustManager.checkServerTrusted( new X509Certificate[] { leafCert, intermediateCert }, "RSA" );
+            Assert.fail( "expected CertificateException when no CA certificates are configured" );
+        }
+        catch ( final CertificateException e )
+        {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
In CA_ONLY mode PwmTrustManager did a flat per-certificate signature check, requiring every server-presented cert to be directly signed by a configured cert. For a leaf -> intermediate -> root chain that meant a configured root alone was insufficient; each intermediate had to be imported too. It now validates via a standard PKIX CertPath trust manager, using configured CA certs as trust anchors and server-supplied intermediates to build the path. This also enforces certificate validity and standard RFC 5280 checks in CA_ONLY mode. Adds PwmTrustManagerTest.