### PR TITLE
PWM-737: Do not serialize password parameters into redirect URLs

### DIFF
--- a/server/src/main/java/password/pwm/http/PwmHttpRequestWrapper.java
+++ b/server/src/main/java/password/pwm/http/PwmHttpRequestWrapper.java
@@ -66,6 +66,14 @@ public class PwmHttpRequestWrapper
                     HttpHeader.Authorization.getHttpName() ) )
             );
 
+    // parameter names (substring-matched) whose values must never be serialized into a URL/query string,
+    // to avoid leaking sensitive submitted values into redirects, web-server logs, browser history, or
+    // referer headers.  'password' also matches 'password1', 'password2', 'currentPassword', etc.
+    private static final Set<String> HTTP_PARAM_SENSITIVE_URL_STRIP_VALUES =
+            Collections.unmodifiableSet( new HashSet<>( Collections.singletonList(
+                    PwmConstants.PARAM_PASSWORD ) )
+            );
+
     public enum Flag
     {
         BypassValidation
@@ -371,6 +379,47 @@ public class PwmHttpRequestWrapper
             returnObj.put( paramName, paramValue );
         }
         return Collections.unmodifiableMap( returnObj );
+    }
+
+    /**
+     * Like {@link #readParametersAsMap()}, but omits parameters whose names indicate a sensitive value
+     * (e.g. a password).  Use this when building a URL that may be redirected to or otherwise exposed,
+     * so that sensitive submitted values are not serialized into a query string (and from there into
+     * web-server logs, browser history, or referer headers).
+     */
+    public Map<String, String> readParametersAsMapForRedirectUrl( )
+            throws PwmUnrecoverableException
+    {
+        final Map<String, String> returnObj = new HashMap<>();
+        for ( final String paramName : parameterNames() )
+        {
+            if ( !isSensitiveUrlParameter( paramName ) )
+            {
+                returnObj.put( paramName, readParameterAsString( paramName ) );
+            }
+        }
+        return Collections.unmodifiableMap( returnObj );
+    }
+
+    /**
+     * Returns true if the given request parameter name indicates a sensitive value that should never be
+     * serialized into a URL/query string (currently password-type parameters).
+     */
+    public static boolean isSensitiveUrlParameter( final String paramName )
+    {
+        if ( paramName == null )
+        {
+            return false;
+        }
+        final String lowerName = paramName.toLowerCase();
+        for ( final String stripValue : HTTP_PARAM_SENSITIVE_URL_STRIP_VALUES )
+        {
+            if ( lowerName.contains( stripValue.toLowerCase() ) )
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Map<String, List<String>> readMultiParametersAsMap( )

--- a/server/src/main/java/password/pwm/http/PwmRequest.java
+++ b/server/src/main/java/password/pwm/http/PwmRequest.java
@@ -577,7 +577,9 @@ public class PwmRequest extends PwmHttpRequestWrapper
 
     public String getURLwithQueryString( ) throws PwmUnrecoverableException
     {
-        return PwmURL.appendAndEncodeUrlParameters( getURLwithoutQueryString(), readParametersAsMap() );
+        // use the redirect-safe parameter map so sensitive submitted values (e.g. passwords) are not
+        // serialized into the query string of a URL that may be redirected to, logged, or stored in history.
+        return PwmURL.appendAndEncodeUrlParameters( getURLwithoutQueryString(), readParametersAsMapForRedirectUrl() );
     }
 
     public boolean endUserFunctionalityAvailable( )

--- a/server/src/main/java/password/pwm/http/filter/SessionFilter.java
+++ b/server/src/main/java/password/pwm/http/filter/SessionFilter.java
@@ -393,7 +393,8 @@ public class SessionFilter extends AbstractPwmFilter
             // check to make sure param is in query string
             if ( req.getQueryString() != null && req.getQueryString().contains( StringUtil.urlDecode( paramName ) ) )
             {
-                if ( !verificationParamName.equals( paramName ) )
+                // never re-serialize sensitive (e.g. password) parameters into the redirect URL
+                if ( !verificationParamName.equals( paramName ) && !PwmHttpRequestWrapper.isSensitiveUrlParameter( paramName ) )
                 {
                     for ( final String value : req.getParameterValues( paramName ) )
                     {

--- a/server/src/test/java/password/pwm/http/PwmHttpRequestWrapperTest.java
+++ b/server/src/test/java/password/pwm/http/PwmHttpRequestWrapperTest.java
@@ -1,0 +1,73 @@
+/*
+ * Password Management Servlets (PWM)
+ * http://www.pwm-project.org
+ *
+ * Copyright (c) 2006-2009 Novell, Inc.
+ * Copyright (c) 2009-2023 The PWM Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package password.pwm.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link PwmHttpRequestWrapper#isSensitiveUrlParameter(String)}, which prevents password-type
+ * request parameters from being serialized into redirect/query-string URLs (and from there into logs,
+ * browser history, or referer headers).
+ */
+public class PwmHttpRequestWrapperTest
+{
+    @Test
+    public void passwordParametersAreSensitive()
+    {
+        Assert.assertTrue( PwmHttpRequestWrapper.isSensitiveUrlParameter( "password" ) );
+        Assert.assertTrue( PwmHttpRequestWrapper.isSensitiveUrlParameter( "password1" ) );
+        Assert.assertTrue( PwmHttpRequestWrapper.isSensitiveUrlParameter( "password2" ) );
+        Assert.assertTrue( PwmHttpRequestWrapper.isSensitiveUrlParameter( "currentPassword" ) );
+    }
+
+    @Test
+    public void passwordMatchIsCaseInsensitive()
+    {
+        Assert.assertTrue( PwmHttpRequestWrapper.isSensitiveUrlParameter( "PASSWORD" ) );
+        Assert.assertTrue( PwmHttpRequestWrapper.isSensitiveUrlParameter( "Password" ) );
+    }
+
+    @Test
+    public void nonSensitiveParametersAreNotStripped()
+    {
+        Assert.assertFalse( PwmHttpRequestWrapper.isSensitiveUrlParameter( "returnUrl" ) );
+        Assert.assertFalse( PwmHttpRequestWrapper.isSensitiveUrlParameter( "forwardURL" ) );
+        Assert.assertFalse( PwmHttpRequestWrapper.isSensitiveUrlParameter( "username" ) );
+        Assert.assertFalse( PwmHttpRequestWrapper.isSensitiveUrlParameter( "" ) );
+    }
+
+    @Test
+    public void nullParameterNameIsNotSensitive()
+    {
+        Assert.assertFalse( PwmHttpRequestWrapper.isSensitiveUrlParameter( null ) );
+    }
+
+    @Test
+    public void tokenParameterIsDeliberatelyNotStrippedFromUrls()
+    {
+        // tokens are intentionally NOT stripped from URLs: email/magic-link flows legitimately carry a
+        // token in the query string and replay that URL after authentication.  (Tokens are still masked
+        // in debug logging via a separate strip set.)
+        Assert.assertFalse( PwmHttpRequestWrapper.isSensitiveUrlParameter( "token" ) );
+        Assert.assertFalse( PwmHttpRequestWrapper.isSensitiveUrlParameter( password.pwm.PwmConstants.PARAM_TOKEN ) );
+    }
+}


### PR DESCRIPTION
getURLwithQueryString() reconstructed a URL from all request parameters (including POSTed password fields) via readParametersAsMap(), and that URL
was used for redirects and as the captured "original requested URL". This
leaked passwords into redirects, web-server logs, browser history, and referer headers, typically on error paths where the parameter is not even
used. Password-type parameters are now stripped when building such URLs (tokens are intentionally preserved for email/magic-link flows). SessionFilter.figureValidationURL() is hardened likewise as defense in depth. Adds PwmHttpRequestWrapperTest.